### PR TITLE
fix mousePosition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+- Fix an issue with the lasso position when the page is scrollable (#50)
+
 ## v0.18.4
 
 - Fix an issues when programmatically trying to `select()` or `hover()` non-existing points

--- a/src/lasso-manager/index.js
+++ b/src/lasso-manager/index.js
@@ -126,8 +126,8 @@ const createLasso = (
     const { left, top } = element.getBoundingClientRect();
 
     return [
-      event.clientX - left + window.scrollX,
-      event.clientY - top + window.scrollY,
+      event.clientX - left,
+      event.clientY - top,
     ];
   };
 

--- a/src/lasso-manager/index.js
+++ b/src/lasso-manager/index.js
@@ -101,7 +101,7 @@ const createLasso = (
     Math.random().toString(36).substring(2, 5) +
     Math.random().toString(36).substring(2, 5);
   initiator.id = `lasso-initiator-${id}`;
-  initiator.style.position = 'absolute';
+  initiator.style.position = 'fixed';
   initiator.style.display = 'flex';
   initiator.style.justifyContent = 'center';
   initiator.style.alignItems = 'center';
@@ -125,10 +125,7 @@ const createLasso = (
   const getMousePosition = (event) => {
     const { left, top } = element.getBoundingClientRect();
 
-    return [
-      event.clientX - left,
-      event.clientY - top,
-    ];
+    return [event.clientX - left, event.clientY - top];
   };
 
   window.addEventListener('mouseup', mouseUpHandler);


### PR DESCRIPTION
When the scatterplot is within an element with some margin/padding to the top and the page is scrollable, then the lasso was misplaced. This has to do that the lasso being drawn relative to the canvas and not to the window. Removing window.scrollX/Y lets the lasso be drawn regardless of how far you have scrolled