### PR TITLE
Fix pointer out event

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2570,8 +2570,8 @@ const createScatterplot = (initialProperties = {}) => {
         pubSub.publish('pointover', hoveredPoint);
     } else {
       needsRedraw = +hoveredPoint >= 0;
-      if (needsRedraw && !selectionSet.has(hoveredPoint)) {
-        setPointConnectionColorState([hoveredPoint], 0);
+      if (needsRedraw) {
+        if (!selectionSet.has(hoveredPoint)) setPointConnectionColorState([hoveredPoint], 0);
         if (!preventEvent) pubSub.publish('pointout', hoveredPoint);
       }
       hoveredPoint = undefined;

--- a/src/index.js
+++ b/src/index.js
@@ -2571,8 +2571,12 @@ const createScatterplot = (initialProperties = {}) => {
     } else {
       needsRedraw = +hoveredPoint >= 0;
       if (needsRedraw) {
-        if (!selectionSet.has(hoveredPoint)) setPointConnectionColorState([hoveredPoint], 0);
-        if (!preventEvent) pubSub.publish('pointout', hoveredPoint);
+        if (!selectionSet.has(hoveredPoint)) {
+          setPointConnectionColorState([hoveredPoint], 0);
+        }
+        if (!preventEvent) {
+          pubSub.publish('pointout', hoveredPoint);
+        }
       }
       hoveredPoint = undefined;
     }


### PR DESCRIPTION
this fixes a small bug where the `pointout` event is not emitted when the point in question is part of the selected set