### PR TITLE
[wip] vite auto-refresh

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -24,7 +24,22 @@ const pages = Object.fromEntries(
 
 export default defineConfig({
   base: './',
-  plugins: [virtualHtmlTemplate({ pages })],
+  plugins: [
+    virtualHtmlTemplate({ pages }),
+    {
+      name: 'inject-vite-client',
+      apply: 'serve', // only for dev server
+      transform(code, id) {
+        if (id.includes('example')) {
+          return `import "/@vite/client";\n${code}`;
+        }
+        return null;
+      },
+      handleHotUpdate({ server }) {
+        server.ws.send({ type: 'full-reload' });
+      },
+    },
+  ],
   build: {
     outDir: 'docs',
     rollupOptions: {


### PR DESCRIPTION
Normally vite handles a request for `index.html`, but `vite-plugin-virtual-html-template` intercepts requests for `.html` and doesn't allow vite to inject a runtime client to handle auto-refreshing.

This PR adds a minimal plugin to inject the `/@vite/client` code during dev and force and auto-refresh. It's not perfect, but it's better than the existing solution.  