### PR TITLE
Add a missing event name

### DIFF
--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -157,6 +157,7 @@ type EventMap = PubSubEvent<
   | 'init'
   | 'destroy'
   | 'backgroundImageReady'
+  | 'select'
   | 'deselect'
   | 'lassoStart'
   | 'transitionStart'


### PR DESCRIPTION
'select' is a valid event name, when a selection of points has been made.