### PR TITLE
Fixed Issue#112 - isMouseInCanvas out of sync

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -458,7 +458,7 @@ const createScatterplot = (
   let maxValueW = 0;
 
   let hoveredPoint;
-  let isMouseInCanvas = false;
+  let isMouseInCanvas = true;
 
   let xScale = initialProperties.xScale || null;
   let yScale = initialProperties.yScale || null;


### PR DESCRIPTION
Fixed https://github.com/flekschas/regl-scatterplot/issues/112

Changed ```isMouseInCanvas``` from ```false``` to ```true``` on startup.

### Behavior Before:

If the cursor is moved within the canvas before the initalization, the ```mouseMoveHandler``` registers ```isMouseInCanvas``` as ```false```. The cursor must be moved out and back of the canvas to re-establish sync. 

https://user-images.githubusercontent.com/70297791/230256743-e5446640-8179-426f-a673-6654b6ce8cd0.mp4


### Behavior After:

The position of the cursor does not matter on startup. Behavior works as expected. 

https://user-images.githubusercontent.com/70297791/230256818-bca0f981-cd19-413a-9272-958723391a65.mp4


