### PR TITLE
fix: correctly check if mouse is over the canvas element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v1.6.4
+
+- Fix a point hovering issue ([#112](https://github.com/flekschas/regl-scatterplot/issues/112))
+
 ## v1.6.3
 
 - Fix an issue with repeated zooming to points


### PR DESCRIPTION
This PR attempts to fix the point hovering issue described in #112.

## Description

> What was changed in this pull request?

Previously we initialized `isMouseInCanvas` as `false`. The `isMouseInCanvas` is making sure that we don't do unnecessary computations if the user mouses around outside the scatterplot. However, in the edge case where the scatterplot instance was initialized when the mouse was already over the canvas element, the mouse enter handler would never fire and `isMouseInCanvas` would never be set to true. That prevented hover effects from working.

This PR fixes this by checking which elements the mouse is hovering on the initial mouse move event.

> Why is it necessary?

Fixes #112

## Checklist

- [ ] Provided a concise title as a [semantic commit message](https://www.conventionalcommits.org) (e.g. "fix: correctly handle undefined properties")
- [x] Updated CHANGELOG.md
- [ ] Added or updated Tests added or updated
- [ ] Documentation added or updated in README.md
- [ ] Example(s) added or updated
- [ ] Screenshot, gif, or video attached for visual changes
