### PR TITLE
fix: improve typing of the select event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Latest
+
+- Added typing support for `EventMap['select']` event ([#119](https://github.com/flekschas/regl-scatterplot/issues/119))
 ## v1.6.5
 
 - Fix typing issue related to `subscribe()` ([#117](https://github.com/flekschas/regl-scatterplot/issues/117))

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -185,7 +185,6 @@ type EventMap = PubSubEvent<
   | 'init'
   | 'destroy'
   | 'backgroundImageReady'
-  | 'select'
   | 'deselect'
   | 'lassoStart'
   | 'transitionStart'
@@ -194,6 +193,7 @@ type EventMap = PubSubEvent<
 > &
   PubSubEvent<'lassoEnd' | 'lassoExtend', { coordinates: number[] }> &
   PubSubEvent<'pointOver' | 'pointOut', number> &
+  PubSubEvent<'select', { points: Array<number> }> &
   PubSubEvent<'points', { points: Array<Array<number>> }> &
   PubSubEvent<'transitionEnd', import('regl').Regl> &
   PubSubEvent<


### PR DESCRIPTION
## Changes

Added typing support for EventMap select event

> Why is it necessary?

Fixes [#119](https://github.com/flekschas/regl-scatterplot/issues/119)

## Attachments

![image](https://user-images.githubusercontent.com/45242072/232762971-39fd6d67-103c-4910-9b69-3ac05cdcc0ff.png)

## Checklist

- [x] Provided a concise title as a [semantic commit message](https://www.conventionalcommits.org) (e.g. "fix: correctly handle undefined properties")
- [x] Updated CHANGELOG.md
- [ ] Added or updated Tests added or updated
- [ ] Documentation added or updated in README.md
- [ ] Example(s) added or updated
- [] Screenshot, gif, or video attached for visual changes
