### PR TITLE
Cancel zoomToPoints if searchIndex is undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## LATEST
+
+- Fix `zoomToPoints` behavior when points are not initialized [#123](https://github.com/flekschas/regl-scatterplot/issues/123)
+
 ## v1.6.6
 
 - Improve type annotations of the `select` event ([#119](https://github.com/flekschas/regl-scatterplot/issues/119))

--- a/src/index.js
+++ b/src/index.js
@@ -2410,7 +2410,7 @@ const createScatterplot = (
    */
   const zoomToPoints = (pointIdxs, options = {}) => {
     if(!searchIndex){
-      return
+      return false;
     }
     const rect = getBBoxOfPoints(pointIdxs);
     const cX = rect.x + rect.width / 2;

--- a/src/index.js
+++ b/src/index.js
@@ -2409,6 +2409,9 @@ const createScatterplot = (
    * @returns {Promise<void>}
    */
   const zoomToPoints = (pointIdxs, options = {}) => {
+    if(!searchIndex){
+      return
+    }
     const rect = getBBoxOfPoints(pointIdxs);
     const cX = rect.x + rect.width / 2;
     const cY = rect.y + rect.height / 2;

--- a/src/index.js
+++ b/src/index.js
@@ -2409,9 +2409,7 @@ const createScatterplot = (
    * @returns {Promise<void>}
    */
   const zoomToPoints = (pointIdxs, options = {}) => {
-    if(!searchIndex){
-      return false;
-    }
+    if (!isInit) return Promise.reject(new Error(ERROR_NOT_INITIALIZED))
     const rect = getBBoxOfPoints(pointIdxs);
     const cX = rect.x + rect.width / 2;
     const cY = rect.y + rect.height / 2;

--- a/tests/index.js
+++ b/tests/index.js
@@ -2337,6 +2337,15 @@ test(
 );
 
 test(
+  'zooming before point initialization',
+  catchError(async () => {
+    const scatterplot = createScatterplot({ canvas: createCanvas() });
+    await scatterplot.zoomToPoints([1, 2]);
+    scatterplot.destroy();
+  })
+);
+
+test(
   'isSupported',
   catchError((t) => {
     const scatterplot = createScatterplot({ canvas: createCanvas() });

--- a/tests/index.js
+++ b/tests/index.js
@@ -2341,6 +2341,12 @@ test(
   catchError(async () => {
     const scatterplot = createScatterplot({ canvas: createCanvas() });
     await scatterplot.zoomToPoints([1, 2]);
+    try{
+      await scatterplot.zoomToPoints([1, 2]);
+      t.fail('zoomToPoints should have thrown an error');
+    } catch(e) {
+      t.equal(e.message, ERROR_NOT_INITIALIZED);
+    }
     scatterplot.destroy();
   })
 );


### PR DESCRIPTION
Cancel zoomToPoints if `searchIndex` is undefined

## Description

> What was changed in this pull request?

Cancel `zoomToPoints` if `searchIndex` is not defined

> Why is it necessary?

Fixes #123

## Checklist

- [x] Provided a concise title as a [semantic commit message](https://www.conventionalcommits.org) (e.g. "fix: correctly handle undefined properties")
- [x] Updated CHANGELOG.md
- [x] Added or updated Tests added or updated
- [ ] Documentation added or updated in README.md
- [ ] Example(s) added or updated
- [ ] Screenshot, gif, or video attached for visual changes
