### PR TITLE
fix: zoomToPoints() when no points were drawn yet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## LATEST
 
 - Fix `zoomToPoints` behavior when points are not initialized [#123](https://github.com/flekschas/regl-scatterplot/issues/123)
+- Add `isPointsDrawn` to `get()` to allow checking if some points have been drawn
 
 ## v1.6.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## LATEST
+
+- Fix `zoomToPoints` behavior when points are not initialized [#123](https://github.com/flekschas/regl-scatterplot/issues/123)
+
 ## v1.6.6
 
 - Improve type annotations of the `select` event ([#119](https://github.com/flekschas/regl-scatterplot/issues/119))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## LATEST
 
 - Fix `zoomToPoints` behavior when points are not initialized [#123](https://github.com/flekschas/regl-scatterplot/issues/123)
-- Add `isPointsDrawn` to `get()` to allow checking if some points have been drawn
+- Add `isDestroyed` and `isPointsDrawn` to `get()`
 
 ## v1.6.6
 

--- a/README.md
+++ b/README.md
@@ -646,6 +646,7 @@ can be read and written via [`scatterplot.get()`](#scatterplot.get) and [`scatte
 | mouseMode                             | string                                       | `'panZoom'`                         | `'panZoom'`, `'lasso'`, or `'rotate'`                           | `true`   | `false`     |
 | performanceMode                       | boolean                                      | `false`                             | can only be set during initialization!                          | `true`   | `false`     |
 | gamma                                 | float                                        | `1`                                 | to control the opacity blending                                 | `true`   | `false`     |
+| isDestroyed                           | boolean                                      | `false`                             |                                                                 | `false`  | `false`     |
 | isPointsDrawn                         | boolean                                      | `false`                             |                                                                 | `false`  | `false`     |
 
 <a name="property-notes" href="#property-notes">#</a> <b>Notes:</b>

--- a/README.md
+++ b/README.md
@@ -646,6 +646,7 @@ can be read and written via [`scatterplot.get()`](#scatterplot.get) and [`scatte
 | mouseMode                             | string                                       | `'panZoom'`                         | `'panZoom'`, `'lasso'`, or `'rotate'`                           | `true`   | `false`     |
 | performanceMode                       | boolean                                      | `false`                             | can only be set during initialization!                          | `true`   | `false`     |
 | gamma                                 | float                                        | `1`                                 | to control the opacity blending                                 | `true`   | `false`     |
+| isPointsDrawn                         | boolean                                      | `false`                             |                                                                 | `false`  | `false`     |
 
 <a name="property-notes" href="#property-notes">#</a> <b>Notes:</b>
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -155,3 +155,6 @@ export const LONG_CLICK_TIME = 500;
 export const Z_NAMES = new Set(['z', 'valueZ', 'valueA', 'value1', 'category']);
 export const W_NAMES = new Set(['w', 'valueW', 'valueB', 'value2', 'value']);
 export const DEFAULT_IMAGE_LOAD_TIMEOUT = 15000;
+
+// Error messages
+export const ERROR_POINTS_NOT_DRAWN = 'Points have not been drawn';

--- a/src/index.js
+++ b/src/index.js
@@ -111,6 +111,7 @@ import {
   Z_NAMES,
   W_NAMES,
   DEFAULT_IMAGE_LOAD_TIMEOUT,
+  ERROR_POINTS_NOT_DRAWN,
 } from './constants';
 
 import {
@@ -2409,7 +2410,8 @@ const createScatterplot = (
    * @returns {Promise<void>}
    */
   const zoomToPoints = (pointIdxs, options = {}) => {
-    if (!isInit) return Promise.reject(new Error(ERROR_NOT_INITIALIZED))
+    if (!isPointsDrawn)
+      return Promise.reject(new Error(ERROR_POINTS_NOT_DRAWN));
     const rect = getBBoxOfPoints(pointIdxs);
     const cX = rect.x + rect.width / 2;
     const cY = rect.y + rect.height / 2;

--- a/src/index.js
+++ b/src/index.js
@@ -2410,7 +2410,7 @@ const createScatterplot = (
    */
   const zoomToPoints = (pointIdxs, options = {}) => {
     if(!searchIndex){
-      return
+      return false;
     }
     const rect = getBBoxOfPoints(pointIdxs);
     const cX = rect.x + rect.width / 2;

--- a/src/index.js
+++ b/src/index.js
@@ -2409,6 +2409,9 @@ const createScatterplot = (
    * @returns {Promise<void>}
    */
   const zoomToPoints = (pointIdxs, options = {}) => {
+    if(!searchIndex){
+      return
+    }
     const rect = getBBoxOfPoints(pointIdxs);
     const cX = rect.x + rect.width / 2;
     const cY = rect.y + rect.height / 2;

--- a/src/index.js
+++ b/src/index.js
@@ -2920,6 +2920,7 @@ const createScatterplot = (
     if (property === 'performanceMode') return performanceMode;
     if (property === 'gamma') return renderer.gamma;
     if (property === 'renderer') return renderer;
+    if (property === 'isDestroyed') return isDestroyed;
     if (property === 'isPointsDrawn') return isPointsDrawn;
 
     return undefined;
@@ -3441,6 +3442,7 @@ const createScatterplot = (
   };
 
   const destroy = () => {
+    isPointsDrawn = false;
     isDestroyed = true;
     cancelFrameListener();
     window.removeEventListener('keyup', keyUpHandler, false);

--- a/src/index.js
+++ b/src/index.js
@@ -2920,6 +2920,7 @@ const createScatterplot = (
     if (property === 'performanceMode') return performanceMode;
     if (property === 'gamma') return renderer.gamma;
     if (property === 'renderer') return renderer;
+    if (property === 'isPointsDrawn') return isPointsDrawn;
 
     return undefined;
   };

--- a/src/index.js
+++ b/src/index.js
@@ -2409,9 +2409,7 @@ const createScatterplot = (
    * @returns {Promise<void>}
    */
   const zoomToPoints = (pointIdxs, options = {}) => {
-    if(!searchIndex){
-      return false;
-    }
+    if (!isInit) return Promise.reject(new Error(ERROR_NOT_INITIALIZED))
     const rect = getBBoxOfPoints(pointIdxs);
     const cX = rect.x + rect.width / 2;
     const cY = rect.y + rect.height / 2;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -145,6 +145,7 @@ export type Properties = {
   opacityByDensityDebounceTime: number;
   points: [number, number][];
   pointsInView: number[];
+  isDestroyed: boolean;
   isPointsDrawn: boolean;
 } & Settable;
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -145,6 +145,7 @@ export type Properties = {
   opacityByDensityDebounceTime: number;
   points: [number, number][];
   pointsInView: number[];
+  isPointsDrawn: boolean;
 } & Settable;
 
 // Options for plot.{draw, select, hover}

--- a/tests/index.js
+++ b/tests/index.js
@@ -2337,6 +2337,15 @@ test(
 );
 
 test(
+  'zooming before point initialization',
+  catchError(async () => {
+    const scatterplot = createScatterplot({ canvas: createCanvas() });
+    await scatterplot.zoomToPoints([1, 2]);
+    scatterplot.destroy();
+  })
+);
+
+test(
   'isSupported',
   catchError((t) => {
     const scatterplot = createScatterplot({ canvas: createCanvas() });

--- a/tests/index.js
+++ b/tests/index.js
@@ -2341,6 +2341,12 @@ test(
   catchError(async () => {
     const scatterplot = createScatterplot({ canvas: createCanvas() });
     await scatterplot.zoomToPoints([1, 2]);
+    try{
+      await scatterplot.zoomToPoints([1, 2]);
+      t.fail('zoomToPoints should have thrown an error');
+    } catch(e) {
+      t.equal(e.message, ERROR_NOT_INITIALIZED);
+    }
     scatterplot.destroy();
   })
 );

--- a/tests/index.js
+++ b/tests/index.js
@@ -1186,6 +1186,26 @@ test(
 );
 
 test(
+  'test that `isPointsDrawn` is set correctly',
+  catchError(async (t) => {
+    const canvas = createCanvas(200, 200);
+    const scatterplot = createScatterplot({ canvas, width: 200, height: 200 });
+
+    t.equal(scatterplot.get('isPointsDrawn'), false);
+    t.equal(scatterplot.get('isDestroyed'), false);
+
+    await scatterplot.draw([[0, 0]]);
+
+    t.equal(scatterplot.get('isPointsDrawn'), true);
+
+    scatterplot.destroy();
+
+    t.equal(scatterplot.get('isDestroyed'), true);
+    t.equal(scatterplot.get('isPointsDrawn'), false);
+  })
+);
+
+test(
   'do _not_ throw an error when calling draw() _before_ destroy()',
   catchError(async (t) => {
     const canvas = createCanvas(200, 200);

--- a/tests/index.js
+++ b/tests/index.js
@@ -44,6 +44,7 @@ import {
   DEFAULT_OPACITY,
   DEFAULT_IMAGE_LOAD_TIMEOUT,
   IMAGE_LOAD_ERROR,
+  ERROR_POINTS_NOT_DRAWN,
 } from '../src/constants';
 
 import { toRgba, isNormFloatArray, isValidBBox } from '../src/utils';
@@ -2337,15 +2338,14 @@ test(
 );
 
 test(
-  'zooming before point initialization',
-  catchError(async () => {
+  'zoomToPoints() before point were drawn should fail',
+  catchError(async (t) => {
     const scatterplot = createScatterplot({ canvas: createCanvas() });
-    await scatterplot.zoomToPoints([1, 2]);
-    try{
+    try {
       await scatterplot.zoomToPoints([1, 2]);
-      t.fail('zoomToPoints should have thrown an error');
-    } catch(e) {
-      t.equal(e.message, ERROR_NOT_INITIALIZED);
+      t.fail('zoomToPoints() should have thrown an error');
+    } catch (e) {
+      t.equal(e.message, ERROR_POINTS_NOT_DRAWN);
     }
     scatterplot.destroy();
   })


### PR DESCRIPTION
This PR supersedes https://github.com/flekschas/regl-scatterplot/pull/124 by adding the necessary changes to make the test pass.

## Description

> What was changed in this pull request?

Throw an error when `zoomToPoints()` is called before points have been drawn. Expose `isDestroyed` and `isPointsDrawn` via `get()`.

> Why is it necessary?

Fixes #123

## Checklist

- [x] Provided a concise title as a [semantic commit message](https://www.conventionalcommits.org) (e.g. "fix: correctly handle undefined properties")
- [x] Updated CHANGELOG.md
- [x] Added or updated Tests added or updated
- [x] Documentation added or updated in README.md
- [ ] Example(s) added or updated
- [ ] Screenshot, gif, or video attached for visual changes
