### PR TITLE
fix: allow to filter out all points by calling `filter([])`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v1.6.8
+
+- Fix `filter()` to allow filtering out all points [#122](https://github.com/flekschas/regl-scatterplot/issues/122)
+- Add `isPointsFiltered` to `get()` to allow determining if any points have been filtered out
+
 ## v1.6.7
 
 - Fix `zoomToPoints` behavior when points are not initialized [#123](https://github.com/flekschas/regl-scatterplot/issues/123)

--- a/README.md
+++ b/README.md
@@ -648,6 +648,7 @@ can be read and written via [`scatterplot.get()`](#scatterplot.get) and [`scatte
 | gamma                                 | float                                        | `1`                                 | to control the opacity blending                                 | `true`   | `false`     |
 | isDestroyed                           | boolean                                      | `false`                             |                                                                 | `false`  | `false`     |
 | isPointsDrawn                         | boolean                                      | `false`                             |                                                                 | `false`  | `false`     |
+| isPointsFiltered                      | boolean                                      | `false`                             |                                                                 | `false`  | `false`     |
 
 <a name="property-notes" href="#property-notes">#</a> <b>Notes:</b>
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -147,6 +147,7 @@ export type Properties = {
   pointsInView: number[];
   isDestroyed: boolean;
   isPointsDrawn: boolean;
+  isPointsFiltered: boolean;
 } & Settable;
 
 // Options for plot.{draw, select, hover}

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -65,3 +65,9 @@ export const catchError = (testFn) => async (t) => {
     t.fail(e.message);
   }
 };
+
+export const isSameElements = (a, b) => {
+  if (a.length !== b.length) return false;
+  const aSet = new Set(a);
+  return b.every((value) => aSet.has(value));
+};


### PR DESCRIPTION
This PR enables filtering out all points by calling `scatterplot.filter([])`;

## Description

> What was changed in this pull request?

This PR enables filtering out all points which was previously not possible. To check if any point filter have been applied, this PR also exposes `isPointsFiltered` via the `get()` function.

> Why is it necessary?

Fixes #122

## Checklist

- [x] Provided a concise title as a [semantic commit message](https://www.conventionalcommits.org) (e.g. "fix: correctly handle undefined properties")
- [x] Updated CHANGELOG.md
- [x] Added or updated Tests added or updated
- [x] Documentation added or updated in README.md
- [ ] Example(s) added or updated
- [ ] Screenshot, gif, or video attached for visual changes
