### PR TITLE
fix: empty selection handling of `select([])`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v1.6.9
+
+- Fix empty `select([])` handling [#132](https://github.com/flekschas/regl-scatterplot/issues/132)
+
 ## v1.6.8
 
 - Fix `filter()` to allow filtering out all points [#122](https://github.com/flekschas/regl-scatterplot/issues/122)

--- a/src/index.js
+++ b/src/index.js
@@ -681,11 +681,13 @@ const createScatterplot = (
    * @param {import('./types').ScatterplotMethodOptions['select']}
    */
   const select = (pointIdxs, { merge = false, preventEvent = false } = {}) => {
-    const pointIdxsArr = Array.isArray(pointIdxs) ? pointIdxs : [pointIdxs];
+    const newSelectedPoints = Array.isArray(pointIdxs)
+      ? pointIdxs
+      : [pointIdxs];
     const currSelectedPoints = [...selectedPoints];
 
     if (merge) {
-      selectedPoints = unionIntegers(selectedPoints, pointIdxsArr);
+      selectedPoints = unionIntegers(selectedPoints, newSelectedPoints);
       if (currSelectedPoints.length === selectedPoints.length) {
         draw = true;
         return;
@@ -694,11 +696,11 @@ const createScatterplot = (
       // Unset previously highlight point connections
       if (selectedPoints && selectedPoints.length)
         setPointConnectionColorState(selectedPoints, 0);
-      selectedPoints = pointIdxsArr;
-      if (currSelectedPoints.length > 0 && selectedPoints.length === 0) {
+      if (currSelectedPoints.length > 0 && newSelectedPoints.length === 0) {
         deselect({ preventEvent });
         return;
       }
+      selectedPoints = newSelectedPoints;
     }
 
     if (hasSameElements(currSelectedPoints, selectedPoints)) {

--- a/tests/index.js
+++ b/tests/index.js
@@ -1995,13 +1995,33 @@ test(
 
     t.equal(selectedPoints.length, 0, 'should have deselected all points');
 
-    scatterplot.select([0, 2, 4], { preventEvent: true });
+    scatterplot.select([0, 2, 4]);
+
+    await wait(0);
+
+    t.deepEqual(
+      scatterplot.get('selectedPoints'),
+      [0, 2, 4],
+      'should have selected three points again'
+    );
+
+    scatterplot.select([]);
 
     await wait(0);
 
     t.equal(
       selectedPoints.length,
       0,
+      'should have deselected all points via `select([])`'
+    );
+
+    scatterplot.select([0, 2, 4], { preventEvent: true });
+
+    await wait(0);
+
+    t.equal(
+      selectedPoints.length + scatterplot.get('selectedPoints').length,
+      3,
       'should have silently selected three points'
     );
 


### PR DESCRIPTION
This PR fixes an empty selection call (e.g., `select([])`)

## Description

> What was changed in this pull request?

Previously, if the current selection was not empty and the new selection was empty, we accidentally updated the current selection to `[]` prior to calling `deselect([])`. This prevented (a) the `deselect` event from firing and (b) didn't properly re-render the plot. Now, we're not going to set `deselect()` handle the setting of the current selection to properly call the `deselect` event and trigger a re-rendering of the plot.

> Why is it necessary?

Fixes #132 

## Checklist

- [x] Provided a concise title as a [semantic commit message](https://www.conventionalcommits.org) (e.g. "fix: correctly handle undefined properties")
- [x] Updated CHANGELOG.md
- [x] Added or updated Tests added or updated
- [ ] Documentation added or updated in README.md
- [ ] Example(s) added or updated
- [ ] Screenshot, gif, or video attached for visual changes
