### PR TITLE
fix: unbind all retainers when instance is destroyed

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3469,6 +3469,7 @@ const createScatterplot = (
     camera.dispose();
     camera = undefined;
     lasso.destroy();
+    lassoManager.destroy();
     pointConnections.destroy();
     reticleHLine.destroy();
     reticleVLine.destroy();

--- a/src/index.js
+++ b/src/index.js
@@ -3459,6 +3459,7 @@ const createScatterplot = (
     canvas.removeEventListener('mouseleave', mouseLeaveCanvasHandler, false);
     canvas.removeEventListener('click', mouseClickHandler, false);
     canvas.removeEventListener('dblclick', mouseDblClickHandler, false);
+    canvas.removeEventListener('wheel', wheelHandler, false);
     if (canvasObserver) {
       canvasObserver.disconnect();
     } else {


### PR DESCRIPTION
> Write one to two sentences summarizing this PR

This PR fixes `scatterplot.destroy()` to properly remove all event listeners bound during instance creation.

## Description

> What was changed in this pull request?

- unbind `wheelHandler` bound to `canvas` when destroying
- call `lassoManager.destroy` when destroying

> Why is it necessary?

Destroyed scatterplot instances are currently retained in memory in full (including the allocated `KDBush` indexes and the webGL context), which leads to memory leaks in applications that create and destroy scatterplots frequently. This happens because there are some event handlers still bound to (detached) DOM elements, so the garbage collection skips the whole thing. The behavior can be replicated and observed as follows:

Adjust the example to call destroy after a timeout. 

```ts
setTimeout(() => {
  scatterplot.destroy();
  // scatterplot needs to be a let binding for this to work
  scatterplot = undefined;
  canvas.parentNode.removeChild(canvas);
}, 2000);
```

Open the `Memory` tab in chrome devtools and open the example. After the canvas is removed, perform a manual garbage collection and take a heap snapshot. You will see that the instance and a canvas element is still held in memory, with the retainers pointing to certain event handlers:

<img width="1437" alt="Screenshot 2023-06-14 at 17 53 37" src="https://github.com/flekschas/regl-scatterplot/assets/1682504/ca2182dd-f881-460b-b24e-ffe1ea0f5910">

Open a new tab and repeat with the fixes applied. When looking at the snapshot now, the instance and canvas are no longer present:

<img width="1440" alt="Screenshot 2023-06-14 at 17 57 36" src="https://github.com/flekschas/regl-scatterplot/assets/1682504/350d7126-355a-4356-94c6-7aa844c19919">


Fixes #___

## Checklist

- [ ] Provided a concise title as a [semantic commit message](https://www.conventionalcommits.org) (e.g. "fix: correctly handle undefined properties")
- [ ] `CHANGELOG.md` updated
- [ ] Tests added or updated
- [ ] Documentation in `README.md` added or updated
- [ ] Example(s) added or updated
- [ ] Screenshot, gif, or video attached for visual changes
