### PR TITLE
fix: Inability to draw with active filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,6 +517,7 @@ Zoom to a specific area specified by a recangle in normalized device coordinates
   - `transition` [default: `false`]: if `true`, the camera will smoothly transition to its new position
   - `transitionDuration` [default: `500`]: the duration in milliseconds over which the transition should occur
   - `transitionEasing` [default: `cubicInOut`]: the easing function, which determines how intermediate values of the transition are calculated
+  - `preventFilterReset` [default: `true`]: if `false`, the active filteredPoints set is not being reset.
 
 **Examples:**
 

--- a/README.md
+++ b/README.md
@@ -517,7 +517,7 @@ Zoom to a specific area specified by a recangle in normalized device coordinates
   - `transition` [default: `false`]: if `true`, the camera will smoothly transition to its new position
   - `transitionDuration` [default: `500`]: the duration in milliseconds over which the transition should occur
   - `transitionEasing` [default: `cubicInOut`]: the easing function, which determines how intermediate values of the transition are calculated
-  - `preventFilterReset` [default: `true`]: if `false`, the active filteredPoints set is not being reset.
+  - `preventFilterReset` [default: `false`]: if `true` and if the number of new points equals the number of already drawn points, the point filter set is not being reset.
 
 **Examples:**
 

--- a/src/index.js
+++ b/src/index.js
@@ -2276,7 +2276,7 @@ const createScatterplot = (
 
           let pointsCached = false;
 
-          if (!options.preventFilterReset) {
+          if (!options.preventFilterReset || points?.length !== numPoints) {
               isPointsFiltered = false;
               filteredPointsSet.clear();
           }

--- a/src/index.js
+++ b/src/index.js
@@ -2279,11 +2279,12 @@ const createScatterplot = (
             // Reset filter
             isPointsFiltered = false;
             filteredPointsSet.clear();
-            if (numPointsChanged) {
-              console.warn(
-                'Cannot preserve filter! The number of points between the previous and current draw call must be identical.'
-              );
-            }
+          }
+          
+          if(options.preventFilterReset && numPointsChanged) {
+            console.warn(
+              'Cannot preserve filter! The number of points between the previous and current draw call must be identical.'
+            );
           }
 
           let pointsCached = false;

--- a/src/index.js
+++ b/src/index.js
@@ -2273,16 +2273,14 @@ const createScatterplot = (
             resolve();
             return;
           }
-          const numPointsChanged = points.length === numPoints;
-          
-          if (!options.preventFilterReset || numPointsChanged) {
-            // Reset filter
-            isPointsFiltered = false;
-            filteredPointsSet.clear();
-          }
 
           let pointsCached = false;
           if (points) {
+            if (!options.preventFilterReset || points.length !== numPoints) {
+              // Reset filter
+              isPointsFiltered = false;
+              filteredPointsSet.clear();
+            }
             if (options.transition) {
               if (!numPointsChanged) {
                 pointsCached = cachePoints(points);

--- a/src/index.js
+++ b/src/index.js
@@ -2281,11 +2281,6 @@ const createScatterplot = (
               filteredPointsSet.clear();
           }
           if (points) {
-            if (points.length !== numPoints) {
-              // Reset filter every time number of points changed
-              isPointsFiltered = false;
-              filteredPointsSet.clear();
-            }
             if (options.transition) {
               if (points.length === numPoints) {
                 pointsCached = cachePoints(points);

--- a/src/index.js
+++ b/src/index.js
@@ -2282,7 +2282,7 @@ const createScatterplot = (
               filteredPointsSet.clear();
             }
             if (options.transition) {
-              if (!numPointsChanged) {
+              if (points.length === numPoints) {
                 pointsCached = cachePoints(points);
               } else {
                 console.warn(

--- a/src/index.js
+++ b/src/index.js
@@ -2275,8 +2275,14 @@ const createScatterplot = (
           }
 
           let pointsCached = false;
+
+          if (!options.preventFilterReset) {
+              // Reset filter
+              isPointsFiltered = false;
+              filteredPointsSet.clear();
+          }
           if (points) {
-            if (!options.preventFilterReset || points.length !== numPoints) {
+            if (points.length !== numPoints) {
               // Reset filter
               isPointsFiltered = false;
               filteredPointsSet.clear();

--- a/src/index.js
+++ b/src/index.js
@@ -2273,7 +2273,7 @@ const createScatterplot = (
             resolve();
             return;
           }
-          const numPointsChanged = points.length !== numPoints;
+          const numPointsChanged = points.length === numPoints;
           
           if (!options.preventFilterReset || numPointsChanged) {
             // Reset filter
@@ -2284,7 +2284,7 @@ const createScatterplot = (
           let pointsCached = false;
           if (points) {
             if (options.transition) {
-              if (numPointsChanged) {
+              if (!numPointsChanged) {
                 pointsCached = cachePoints(points);
               } else {
                 console.warn(

--- a/src/index.js
+++ b/src/index.js
@@ -2273,23 +2273,23 @@ const createScatterplot = (
             resolve();
             return;
           }
-          if (!options.preventFilterReset) {
+          const numPointsChanged = points.length !== numPoints;
+          
+          if (!options.preventFilterReset || numPointsChanged) {
             // Reset filter
             isPointsFiltered = false;
             filteredPointsSet.clear();
-          } else if (
-            options.preventFilterReset &&
-            points.length !== numPoints
-          ) {
-            console.warn(
-              'Cannot preserve filter! The number of points between the previous and current draw call must be identical.'
-            );
+            if (numPointsChanged) {
+              console.warn(
+                'Cannot preserve filter! The number of points between the previous and current draw call must be identical.'
+              );
+            }
           }
 
           let pointsCached = false;
           if (points) {
             if (options.transition) {
-              if (points.length === numPoints) {
+              if (numPointsChanged) {
                 pointsCached = cachePoints(points);
               } else {
                 console.warn(

--- a/src/index.js
+++ b/src/index.js
@@ -2273,10 +2273,18 @@ const createScatterplot = (
             resolve();
             return;
           }
-
-          // Reset filter
-          isPointsFiltered = false;
-          filteredPointsSet.clear();
+          if (!options.preventFilterReset) {
+            // Reset filter
+            isPointsFiltered = false;
+            filteredPointsSet.clear();
+          } else if (
+            options.preventFilterReset &&
+            points.length !== numPoints
+          ) {
+            console.warn(
+              'Cannot preserve filter! The number of points between the previous and current draw call must be identical.'
+            );
+          }
 
           let pointsCached = false;
           if (points) {

--- a/src/index.js
+++ b/src/index.js
@@ -2280,12 +2280,6 @@ const createScatterplot = (
             isPointsFiltered = false;
             filteredPointsSet.clear();
           }
-          
-          if(options.preventFilterReset && numPointsChanged) {
-            console.warn(
-              'Cannot preserve filter! The number of points between the previous and current draw call must be identical.'
-            );
-          }
 
           let pointsCached = false;
           if (points) {

--- a/src/index.js
+++ b/src/index.js
@@ -2277,13 +2277,12 @@ const createScatterplot = (
           let pointsCached = false;
 
           if (!options.preventFilterReset) {
-              // Reset filter
               isPointsFiltered = false;
               filteredPointsSet.clear();
           }
           if (points) {
             if (points.length !== numPoints) {
-              // Reset filter
+              // Reset filter every time number of points changed
               isPointsFiltered = false;
               filteredPointsSet.clear();
             }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -156,6 +156,7 @@ export interface ScatterplotMethodOptions {
     transition: boolean;
     transitionDuration: number;
     transitionEasing: (t: number) => number;
+    preventFilterReset: boolean;
   }>;
   hover: Partial<{
     showReticleOnce: boolean;

--- a/tests/index.js
+++ b/tests/index.js
@@ -1949,6 +1949,41 @@ test(
 );
 
 test(
+  'draw() with preventFilterReset',
+  catchError(async (t) => {
+    const scatterplot = createScatterplot({ canvas: createCanvas() });
+
+    const filteredPoints = [0, 1, 2];
+
+    const points = [
+      [0, 0],
+      [1, 1],
+      [1, -1],
+      [-1, -1],
+      [-1, 1],
+    ];
+
+    await scatterplot.draw([points], { preventFilterReset: true });
+
+    await scatterplot.filter(filteredPoints);
+    await wait(0);
+
+    t.deepEqual(
+      scatterplot.get('isPointsFiltered'),
+      true,
+      '`isPointsFiltered` should be `true` as draw has been invoked with preventFilterReset'
+    );
+
+    t.ok(
+      isSameElements(scatterplot.get('filteredPoints'), filteredPoints),
+      'all points should be filtered in'
+    );
+
+    scatterplot.destroy();
+  })
+);
+
+test(
   'select()',
   catchError(async (t) => {
     const scatterplot = createScatterplot({ canvas: createCanvas() });

--- a/tests/index.js
+++ b/tests/index.js
@@ -1989,8 +1989,6 @@ test(
       '`isPointsFiltered` should be `false` as draw has been invoked with different number of points'
     );
 
-    t.equal(scatterplot.get('filteredPoints'), undefined, '`filteredPoints` should be undefined as draw has been invoked with different number of points');
-
     scatterplot.destroy();
   })
 );

--- a/tests/index.js
+++ b/tests/index.js
@@ -1963,7 +1963,7 @@ test(
       [-1, 1],
     ];
 
-    await scatterplot.draw([points], { preventFilterReset: true });
+    await scatterplot.draw(points);
 
     await scatterplot.filter(filteredPoints);
     await wait(0);

--- a/tests/index.js
+++ b/tests/index.js
@@ -1968,6 +1968,15 @@ test(
     await scatterplot.filter(filteredPoints);
     await wait(0);
 
+    t.ok(
+      isSameElements(scatterplot.get('filteredPoints'), filteredPoints),
+      `only points ${filteredPoints} should be filtered in`
+    );
+
+    const updatedPoints = points.map(([x, y]) => [x + 1, y + 1]);
+
+    await scatterplot.draw(updatedPoints, { preventFilterReset: true });
+
     t.equal(
       scatterplot.get('isPointsFiltered'),
       true,
@@ -1976,17 +1985,7 @@ test(
 
     t.ok(
       isSameElements(scatterplot.get('filteredPoints'), filteredPoints),
-      'all points should be filtered in'
-    );
-
-    await scatterplot.draw([...points, [0.5, 0.5]], {
-      preventFilterReset: true,
-    });
-
-    t.equal(
-      scatterplot.get('isPointsFiltered'),
-      false,
-      '`isPointsFiltered` should be `false` as draw has been invoked with different number of points'
+      'the filtered points should be the same as before'
     );
 
     scatterplot.destroy();

--- a/tests/index.js
+++ b/tests/index.js
@@ -1968,7 +1968,7 @@ test(
     await scatterplot.filter(filteredPoints);
     await wait(0);
 
-    t.deepEqual(
+    t.equal(
       scatterplot.get('isPointsFiltered'),
       true,
       '`isPointsFiltered` should be `true` as draw has been invoked with preventFilterReset'
@@ -1978,6 +1978,18 @@ test(
       isSameElements(scatterplot.get('filteredPoints'), filteredPoints),
       'all points should be filtered in'
     );
+
+    await scatterplot.draw([...points, [0.5, 0.5]], {
+      preventFilterReset: true,
+    });
+
+    t.equal(
+      scatterplot.get('isPointsFiltered'),
+      false,
+      '`isPointsFiltered` should be `false` as draw has been invoked with different number of points'
+    );
+
+    t.equal(scatterplot.get('filteredPoints'), undefined, '`filteredPoints` should be undefined as draw has been invoked with different number of points');
 
     scatterplot.destroy();
   })

--- a/tests/index.js
+++ b/tests/index.js
@@ -1964,7 +1964,7 @@ test(
     ];
 
     await scatterplot.draw(points);
-
+    console.log(scatterplot.get('filteredPoints'));
     await scatterplot.filter(filteredPoints);
     await wait(0);
 
@@ -1985,6 +1985,22 @@ test(
 
     t.ok(
       isSameElements(scatterplot.get('filteredPoints'), filteredPoints),
+      'the filtered points should be the same as before'
+    );
+
+    await scatterplot.draw([...updatedPoints, [0.5, 0.5]], {
+      preventFilterReset: true,
+    });
+
+    t.equal(
+      scatterplot.get('isPointsFiltered'),
+      false,
+      '`isPointsFiltered` should be `false` as draw has been invoked with different number of points'
+    );
+
+    t.equal(
+      scatterplot.get('filteredPoints').length,
+      updatedPoints.length + 1,
       'the filtered points should be the same as before'
     );
 

--- a/tests/index.js
+++ b/tests/index.js
@@ -1964,7 +1964,7 @@ test(
     ];
 
     await scatterplot.draw(points);
-    console.log(scatterplot.get('filteredPoints'));
+
     await scatterplot.filter(filteredPoints);
     await wait(0);
 
@@ -2001,7 +2001,7 @@ test(
     t.equal(
       scatterplot.get('filteredPoints').length,
       updatedPoints.length + 1,
-      'the filtered points should be the same as before'
+      'the filtered points should be reset as draw has been invoked with different number of points'
     );
 
     scatterplot.destroy();


### PR DESCRIPTION
Adds `preventFilterReset` option to `ScatterplotMethodOptions['draw']` to allow re-drawing while keeping the current active filter.

## Description

> What was changed in this pull request?

- Added `preventFilterReset` option to `ScatterplotMethodOptions['draw']`

> Why is it necessary?

Fixes #136 

## Checklist

- [x] Provided a concise title as a [semantic commit message](https://www.conventionalcommits.org) (e.g. "fix: correctly handle undefined properties")
- [x] `CHANGELOG.md` updated
- [x] Tests added or updated
- [x] Documentation in `README.md` added or updated
