### PR TITLE
fix: filteredPoints not in gettable scatter properties

### DIFF
--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -148,6 +148,7 @@ export type Properties = {
   isDestroyed: boolean;
   isPointsDrawn: boolean;
   isPointsFiltered: boolean;
+  filteredPoints: number[];
 } & Settable;
 
 // Options for plot.{draw, select, hover}


### PR DESCRIPTION

> Why is it necessary?

Fixes #[138](https://github.com/flekschas/regl-scatterplot/issues/138)


