### PR TITLE
fix: drawing a single connecting line between points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - Add missing `filteredPoints` type definition. [#139](https://github.com/flekschas/regl-scatterplot/pull/139)
 - Add missing `selectedPoints` type definition.
+- Fix drawing a single connecting line between points [#125](https://github.com/flekschas/regl-scatterplot/issues/125)
+- Fix `draw()`'s promise resolution when `showPointConnections` is `true`. The promise is now resolved after both, the points and point connections, have been drawn.
 - Set minimum Node version to `16` and minimum npm version to `7`. You might still be able to use `regl-scatterplot` with older version but it's not advised.
 
 ## 1.6.10

--- a/tests/index.js
+++ b/tests/index.js
@@ -1226,6 +1226,43 @@ test(
   })
 );
 
+test(
+  'test drawing point connections via `showLineConnections`',
+  catchError(async (t) => {
+    const scatterplot = createScatterplot({
+      canvas: createCanvas(200, 200),
+      width: 200,
+      height: 200,
+      showPointConnections: true,
+    });
+
+    let numConnectionsDraws = 0;
+    scatterplot.subscribe('pointConnectionsDraw', () => {
+      ++numConnectionsDraws;
+    });
+
+    await scatterplot.draw(
+      new Array(10)
+        .fill()
+        .map((_, i) => [-1 + (i / 6) * 2, -1 + Math.random() * 2, i, 1, 0])
+    );
+    await wait(0);
+
+    t.equal(numConnectionsDraws, 1, 'should have drawn the connections once');
+
+    await scatterplot.draw(
+      new Array(10)
+        .fill()
+        .map((e, i) => [-1 + (i / 6) * 2, -1 + Math.random() * 2, i, 1, i % 5])
+    );
+    await wait(0);
+
+    t.equal(numConnectionsDraws, 2, 'should have drawn the connections once');
+
+    scatterplot.destroy();
+  })
+);
+
 test('tests involving mouse events', async (t2) => {
   await t2.test(
     'draw(), clear(), publish("select")',


### PR DESCRIPTION
This PR ensures that a single line connecting all points is drawn correctly.

## Description

> What was changed in this pull request?

Previously, when one attempted to draw a single point connection that connects all points, no line would be drawn. This is now working.

As part of this fix, I also fixed the `draw()` functions resolution to await the drawing of point connections (when `showPointConnections` is set to `true`). Previously, `draw()` would resolve as soon as the points were drawn but drawing lines typically takes longer. Hence, `draw()` resolved too early. With this PR, when `showPointConnections` is `true`, `draw()` will resolve after both, the points and the connections, have been drawn.

> Why is it necessary?

Fixes #125

## Checklist

- [x] Provided a concise title as a [semantic commit message](https://www.conventionalcommits.org) (e.g. "fix: correctly handle undefined properties")
- [x] `CHANGELOG.md` updated
- [x] Tests added or updated
- [ ] Documentation in `README.md` added or updated
- [ ] Example(s) added or updated
- [ ] Screenshot, gif, or video attached for visual changes
