### PR TITLE
fix: aspect ratio and opacity types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.8.1
+
+- Add ability to set `aspectRatio` in the constructor
+- Add type for `aspectRatio`
+- Fix type of `opacity`
+
 ## 1.8.0
 
 - Add `scatterplot.getScreenPosition(pointIdx)` to retrieve the screen position of a point by its index.

--- a/src/index.js
+++ b/src/index.js
@@ -301,7 +301,8 @@ const createScatterplot = (
   let lassoPointsCurr = [];
   let searchIndex;
   let viewAspectRatio;
-  let dataAspectRatio = DEFAULT_DATA_ASPECT_RATIO;
+  let dataAspectRatio =
+    initialProperties.aspectRatio || DEFAULT_DATA_ASPECT_RATIO;
   let projectionLocal;
   let projection;
   let model;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -94,13 +94,14 @@ interface BaseOptions {
   showPointConnections: boolean;
   showReticle: boolean;
   reticleColor: Color;
-  opacity: number;
+  opacity: number | Array<number>;
   opacityByDensityFill: number;
   opacityInactiveMax: number;
   opacityInactiveScale: number;
   height: 'auto' | number;
   width: 'auto' | number;
   gamma: number;
+  aspectRatio: number;
   // Nullifiable
   backgroundImage: null | import('regl').Texture2D | string;
   colorBy: null | DataEncoding;


### PR DESCRIPTION
This PR fixes types and enables setting the aspect ratio in the constructor

## Description

> What was changed in this pull request?

- Add ability to set `aspectRatio` in the constructor
- Add type for `aspectRatio`
- Fix type of `opacity`

> Why is it necessary?

Fixes #146

## Checklist

- [x] Provided a concise title as a [semantic commit message](https://www.conventionalcommits.org) (e.g. "fix: correctly handle undefined properties")
- [x] `CHANGELOG.md` updated
- [ ] Tests added or updated
- [ ] Documentation in `README.md` added or updated
- [ ] Example(s) added or updated
- [ ] Screenshot, gif, or video attached for visual changes
