### PR TITLE
add: new `drawing` event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.9.0
+
+- Add `drawing` event that is _always fired synchronously_ before the end of a draw call. This event is useful for drawing other things as part of an animation frame. The main difference to the default `draw` event is that the `draw` event is fired asynchronously (like all other events) after the draw call such that the draw call itself isn't blocked.
+- Fix: pass `{ camera, view, xScale, yScale }` as the payload of the `draw` event as specified in the docs.
+
 ## 1.8.5
 
 - Fix: add `d3-scale` types as a dev dependency [#153](https://github.com/flekschas/regl-scatterplot/issues/153)

--- a/README.md
+++ b/README.md
@@ -929,6 +929,7 @@ Render Regl draw instructions into a target canvas using the renderer.
 | unfilter             | when the point filter is reset             | `undefined`                        |
 | view                 | when the view has changes                  | `{ camera, view, xScale, yScale }` |
 | draw                 | when the plot was drawn                    | `{ camera, view, xScale, yScale }` |
+| drawing              | when the plot is being drawn               | `{ camera, view, xScale, yScale }` |
 | lassoStart           | when the lasso selection has started       | `undefined`                        |
 | lassoExtend          | when the lasso selection has extended      | `{ coordinates }`                  |
 | lassoEnd             | when the lasso selection has ended         | `{ coordinates }`                  |

--- a/example/text-labels.js
+++ b/example/text-labels.js
@@ -103,15 +103,17 @@ scatterplot.subscribe('deselect', () => {
 });
 
 const showPointLabels = (pointsInView, xScale, yScale) => {
-  textOverlayCtx.clearRect(0, 0, canvas.width, canvas.height);
+  textOverlayCtx.clearRect(0, 0, textOverlayEl.width, textOverlayEl.height);
   textOverlayCtx.fillStyle = 'rgb(255, 255, 255)';
 
+  const dpr = window.devicePixelRatio;
+
   for (let i = 0; i < pointsInView.length; i++) {
+    const [x, y] = points[pointsInView[i]];
     textOverlayCtx.fillText(
       pointsInView[i],
-      xScale(points[pointsInView[i]][0]) * window.devicePixelRatio,
-      yScale(points[pointsInView[i]][1]) * window.devicePixelRatio -
-        overlayFontSize * 1.2 * window.devicePixelRatio
+      xScale(x) * dpr,
+      yScale(y) * dpr - overlayFontSize * 1.2 * dpr
     );
   }
 };
@@ -120,7 +122,7 @@ const hidePointLabels = () => {
   textOverlayCtx.clearRect(0, 0, canvas.width, canvas.height);
 };
 
-scatterplot.subscribe('view', ({ xScale, yScale }) => {
+scatterplot.subscribe('drawing', ({ xScale, yScale }) => {
   const pointsInView = scatterplot.get('pointsInView');
   if (pointsInView.length <= maxPointLabels) {
     showPointLabels(pointsInView, xScale, yScale);

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "gl-matrix": "~3.4.3",
         "kdbush": "~3.0.0",
         "lodash-es": "~4.17.21",
-        "pub-sub-es": "~2.0.2",
+        "pub-sub-es": "~2.1.2",
         "regl": "~2.1.0",
         "regl-line": "~1.0.0"
       },
@@ -63,7 +63,7 @@
         "npm": ">=7.0.0"
       },
       "peerDependencies": {
-        "pub-sub-es": "~2.0.2",
+        "pub-sub-es": "~2.1.2",
         "regl": "~2.1.0"
       }
     },
@@ -10008,9 +10008,9 @@
       "dev": true
     },
     "node_modules/pub-sub-es": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/pub-sub-es/-/pub-sub-es-2.0.2.tgz",
-      "integrity": "sha512-CQqZaKOGF6tWb+6XUGJNMHFZ308ZrgjNXTR4einx265b/L/yYKNEpcD7PkYLNq3CBV0K3qyIXSbX2Jg63ra9sw=="
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/pub-sub-es/-/pub-sub-es-2.1.2.tgz",
+      "integrity": "sha512-vYnAN2DbghNmz1sUXL+j+iEiIPmfEzbJFeRFq9H6IiwAx+QffMu7ASplxGb+AgShLbr8R65hb9YhXn7/tAYYWw=="
     },
     "node_modules/pump": {
       "version": "3.0.0",
@@ -20099,9 +20099,9 @@
       "dev": true
     },
     "pub-sub-es": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/pub-sub-es/-/pub-sub-es-2.0.2.tgz",
-      "integrity": "sha512-CQqZaKOGF6tWb+6XUGJNMHFZ308ZrgjNXTR4einx265b/L/yYKNEpcD7PkYLNq3CBV0K3qyIXSbX2Jg63ra9sw=="
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/pub-sub-es/-/pub-sub-es-2.1.2.tgz",
+      "integrity": "sha512-vYnAN2DbghNmz1sUXL+j+iEiIPmfEzbJFeRFq9H6IiwAx+QffMu7ASplxGb+AgShLbr8R65hb9YhXn7/tAYYWw=="
     },
     "pump": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -39,12 +39,12 @@
     "gl-matrix": "~3.4.3",
     "kdbush": "~3.0.0",
     "lodash-es": "~4.17.21",
-    "pub-sub-es": "~2.0.2",
+    "pub-sub-es": "~2.1.2",
     "regl": "~2.1.0",
     "regl-line": "~1.0.0"
   },
   "peerDependencies": {
-    "pub-sub-es": "~2.0.2",
+    "pub-sub-es": "~2.1.2",
     "regl": "~2.1.0"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -3547,6 +3547,13 @@ const createScatterplot = (
       });
     }, canvas);
 
+    const renderView = {
+      view: camera.view,
+      camera,
+      xScale,
+      yScale,
+    };
+
     // Publish camera change
     if (isViewChanged) {
       updateScales();
@@ -3554,19 +3561,15 @@ const createScatterplot = (
       if (preventEventView) {
         preventEventView = false;
       } else {
-        pubSub.publish('view', {
-          view: camera.view,
-          camera,
-          xScale,
-          yScale,
-        });
+        pubSub.publish('view', renderView);
       }
     }
 
     draw = false;
     drawReticleOnce = false;
 
-    pubSub.publish('draw');
+    pubSub.publish('drawing', renderView, { async: false });
+    pubSub.publish('draw', renderView);
   });
 
   const redraw = () => {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -213,7 +213,7 @@ type EventMap = PubSubEvent<
   PubSubEvent<'points', { points: Array<Array<number>> }> &
   PubSubEvent<'transitionEnd', import('regl').Regl> &
   PubSubEvent<
-    'view' | 'draw',
+    'view' | 'draw' | 'drawing',
     Pick<Properties, 'camera' | 'xScale' | 'yScale'> & {
       view: Properties['cameraView'];
     }

--- a/tests/index.js
+++ b/tests/index.js
@@ -2821,6 +2821,35 @@ test(
   })
 );
 
+test(
+  'test "drawing" event',
+  catchError(async (t) => {
+    const scatterplot = createScatterplot({ canvas: createCanvas() });
+
+    let numDrawCalls = 0;
+    let numDrawingCalls = 0;
+
+    scatterplot.subscribe('draw', () => ++numDrawCalls);
+    scatterplot.subscribe('drawing', () => ++numDrawingCalls);
+
+    await new Promise((resolve) => {
+      scatterplot.subscribe('init', resolve);
+    });
+
+    const isDrawn = scatterplot.draw([[-1, 1]]);
+    await nextAnimationFrame();
+
+    t.equal(numDrawCalls, 0, 'should not have registered any "draw" event');
+    t.equal(numDrawingCalls, 1, 'should have registered one "drawing" event');
+
+    await isDrawn;
+
+    t.equal(numDrawCalls, 1, 'should have registered one "draw" event');
+
+    scatterplot.destroy();
+  })
+);
+
 /* --------------------------------- Utils ---------------------------------- */
 
 test(


### PR DESCRIPTION
This PR adds a new event called `drawing` whose callback listeners are _always_ triggered synchronously. In addition, this PR fixes a discrepancy of the `draw` event payload between the docs and implementation.

## Description

> What was changed in this pull request?

1. Introduced a new `drawing` event that is fired at the end of the draw call before the draw call finished.
2. Exposed `{ camera, view, xScale, yScale }` as the payload of the `draw` event.

> Why is it necessary?

The new `drawing` event allows for rendering other things as part of the same animation frame. Previously this was only possible if regl-scatterplot was created with the `syncEvents` option. This option, however, has the negative side effect of making all event callback listeners fire synchronously, which is not advisable.

E.g., rendering text labels is now in sync with the scatter plot rendering.

![no-lag](https://github.com/flekschas/regl-scatterplot/assets/932103/8dcc745a-94cc-4841-8bc7-c9074321e7ab)

As opposed to the previous lag

![lag](https://github.com/flekschas/regl-scatterplot/assets/932103/c3c8632d-cd97-45bc-a7dd-ad0b17c73fd7)

## Checklist

- [x] Provided a concise title as a [semantic commit message](https://www.conventionalcommits.org) (e.g. "fix: correctly handle undefined properties")
- [x] `CHANGELOG.md` updated
- [x] Tests added or updated
- [x] Documentation in `README.md` added or updated
- [x] Example(s) added or updated
- [x] Screenshot, gif, or video attached for visual changes
