### PR TITLE
fix: fixed pubsub related types

### DIFF
--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -219,13 +219,21 @@ type EventMap = PubSubEvent<
     }
   >;
 
+export type EventHandler<EventName extends keyof EventMap> = (payload: EventMap[EventName]) => void;
+
+export type Subscription<EventName extends keyof EventMap> = {
+  event: EventName;
+  handler: EventHandler<EventName>;
+};
+
 export interface PubSub {
   subscribe<EventName extends keyof EventMap>(
     eventName: EventName,
-    eventHandler: (payload: EventMap[EventName]) => void,
+    eventHandler: EventHandler<EventName>,
     times?: number
-  ): void;
-  unsubscribe(eventName: keyof EventMap): void;
+  ): Subscription<EventName>;
+  unsubscribe<EventName extends keyof EventMap>(eventName: EventName, eventHandler: EventHandler<EventName>): void;
+  unsubscribe<EventName extends keyof EventMap>(subscription: Subscription<EventName>): void;
   publish<EventName extends keyof EventMap>(
     eventName: EventName,
     payload: EventMap[EventName]


### PR DESCRIPTION
> Write one to two sentences summarizing this PR

Current pubsub types do not match actual types used by pub-sub-es. This PR fixes them.

> What was changed in this pull request?

Added missing return value in subscribe and added missing argument/overload for unsubscribe. Also added helper types for subscription object and handler.

> Why is it necessary?

Because you can't use unsubscribe properly from events right now.

## Checklist

- [x] Provided a concise title as a [semantic commit message](https://www.conventionalcommits.org) (e.g. "fix: correctly handle undefined properties")
- [ ] `CHANGELOG.md` updated
- [ ] Tests added or updated
- [ ] Documentation in `README.md` added or updated
- [ ] Example(s) added or updated
- [ ] Screenshot, gif, or video attached for visual changes
