### PR TITLE
fix: two issues related to point filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.9.4
+
+- Fix: `scatterplot.draw(newPoints, { preventFilterReset })` should preserves the filter ([Jupyter-Scatter#134](https://github.com/flekschas/jupyter-scatter/issues/134))
+- Fix: `scatterplot.hover(filteredOutPoint)` should not trigger a hover event
+
 ## 1.9.3
 
 - Fix: point connection initial color map


### PR DESCRIPTION
This PR fixes two issues related point filtering

## Description

> What was changed in this pull request?

1. After filter out some points, trying to programmatically hover them with `scatterplot.hover(filteredOutPointIdx)` will not work anymore
2. When re-drawing points with `preventFilterReset: true`, the point index buffer will not be recreated to persist the current filter state

Here's an example showing the `scatterplot.draw(newPoints, { preventFilterReset: true })` works as intended now

https://github.com/flekschas/regl-scatterplot/assets/932103/e5e8ae77-d311-4740-af8e-9bbbc01f7ba6

I simulated this with the basic example using:
```js
setTimeout(() => {
  scatterplot.filter(
    scatterplot
      .get('points')
      .map((point, i) => [point, i])
      .filter(([point]) => point[0] >= 0)
      .map(([_, i]) => i)
  );
  console.log('Filter down to points on the right');
}, [500]);

setTimeout(() => {
  scatterplot.draw(scatterplot.get('points'), { preventFilterReset: true });
  console.log('Re-draw points with `preventFilterReset: true`');
}, [1000]);

setTimeout(() => {
  scatterplot.unfilter();
  console.log('Unset filter');
}, [3000]);
```

> Why is it necessary?

Fixes an issue raised in [Jupyter-Scatter](https://github.com/flekschas/jupyter-scatter/issues/134)

## Checklist

- [x] Provided a concise title as a [semantic commit message](https://www.conventionalcommits.org) (e.g. "fix: correctly handle undefined properties")
- [x] `CHANGELOG.md` updated
- [x] Tests added or updated
- [ ] Documentation in `README.md` added or updated
- [ ] Example(s) added or updated
- [x] Screenshot, gif, or video attached for visual changes
