### PR TITLE
fix: kdbush worker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.10.2
 
 - Fix: expose x start/end and y start/end for horizontal and vertical line annotations.
+- Fix: ensure KDBush worker works in prod build
 
 ## 1.10.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.10.2
+
+- Fix: expose x start/end and y start/end for horizontal and vertical line annotations.
+
 ## 1.10.1
 
 - Fix: ensure single annotations render properly ([#187](https://github.com/flekschas/regl-scatterplot/issues/187))

--- a/README.md
+++ b/README.md
@@ -424,9 +424,9 @@ Draw line-based annotations of the following kind in normalized device coordinat
 **Arguments:**
 
 - `annotations` is expected to be a list of the following objects:
-  - For horizontal lines: `{ y: number, lineColor?: Color, lineWidth?: number }`
-  - For vertical lines: `{ x: number, lineColor?: Color, lineWidth?: number }`
-  - For rectangle : `{ x: number, y: number, width: number, height: number, lineColor?: Color, lineWidth?: number }` or `{ x1: number, y1: number, x2: number, y2: number, lineColor?: Color, lineWidth?: number }`
+  - For horizontal lines: `{ y: number, x1?: number, x2?: number, lineColor?: Color, lineWidth?: number }`
+  - For vertical lines: `{ x: number, y1?: number, y2?: number, lineColor?: Color, lineWidth?: number }`
+  - For rectangle : `{ x1: number, y1: number, x2: number, y2: number, lineColor?: Color, lineWidth?: number }` or `{ x: number, y: number, width: number, height: number, lineColor?: Color, lineWidth?: number }`
   - For polygons or lines: `{ vertices: [number, number][], lineColor?: Color, lineWidth?: number }`
 
 **Returns:** a Promise object that resolves once the annotations have been drawn or transitioned.

--- a/example/annotations.js
+++ b/example/annotations.js
@@ -194,6 +194,7 @@ setNumPoint(numPoints);
 scatterplot.drawAnnotations([
   { x: 0, lineColor: [1, 1, 1, 0.1], lineWidth: 1 },
   { y: 0, lineColor: [1, 1, 1, 0.1], lineWidth: 1 },
+  { y: 0.5, x1: -0.9, x2: 0.9, lineColor: [1, 1, 1, 1], lineWidth: 1 },
   {
     x1: -1,
     y1: -1,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "regl-scatterplot",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "regl-scatterplot",
-      "version": "1.10.1",
+      "version": "1.10.2",
       "license": "MIT",
       "dependencies": {
         "@flekschas/utils": "^0.31.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "regl-scatterplot",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "description": "A WebGL-Powered Scalable Interactive Scatter Plot Library",
   "author": "Fritz Lekschas",
   "keywords": [

--- a/src/index.js
+++ b/src/index.js
@@ -2435,9 +2435,9 @@ const createScatterplot = (
       for (const annotation of newAnnotations) {
         if (isHorizontalLine(annotation)) {
           newPoints.push([
-            -annotationHVLineLimit,
+            annotation.x1 ?? -annotationHVLineLimit,
             annotation.y,
-            annotationHVLineLimit,
+            annotation.x2 ?? annotationHVLineLimit,
             annotation.y,
           ]);
           addColorAndWidth(annotation);
@@ -2447,9 +2447,9 @@ const createScatterplot = (
         if (isVerticalLine(annotation)) {
           newPoints.push([
             annotation.x,
-            -annotationHVLineLimit,
+            annotation.y1 ?? -annotationHVLineLimit,
             annotation.x,
-            annotationHVLineLimit,
+            annotation.y2 ?? annotationHVLineLimit,
           ]);
           addColorAndWidth(annotation);
           continue;

--- a/src/kdbush.js
+++ b/src/kdbush.js
@@ -5,13 +5,17 @@ const KDBush = createKDBushClass();
 const WORKER_THRESHOLD = 1000000;
 
 const createWorker = (fn) => {
-  let kdbushStr = createKDBushClass.toString();
-  kdbushStr = kdbushStr.substring(10, kdbushStr.length - 18);
-  let fnStr = fn.toString();
-  fnStr = fnStr.substring(10, fnStr.length - 2);
+  const kdbushStr = createKDBushClass.toString();
+  const fnStr = fn.toString();
+  const workerStr =
+    `const createKDBushClass = ${kdbushStr};` +
+    'KDBush = createKDBushClass();' +
+    `const createWorker = ${fnStr};` +
+    'createWorker();';
+
   return new Worker(
     window.URL.createObjectURL(
-      new Blob([`${kdbushStr};${fnStr}`], {
+      new Blob([workerStr], {
         type: 'text/javascript',
       })
     )

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -92,10 +92,14 @@ interface BaseAnnotation {
 
 interface AnnotationHLine extends BaseAnnotation {
   y: number;
+  x1?: number;
+  x2?: number;
 }
 
 interface AnnotationVLine extends BaseAnnotation {
   x: number;
+  y1?: number;
+  y2?: number;
 }
 
 interface AnnotationDomRect extends BaseAnnotation {


### PR DESCRIPTION
This PR fixes the KDBush worker in the production build.

## Description

> What was changed in this pull request?

To avoid name clashes, the worker now depends on a named function declaration.

> Why is it necessary?

Previously it was possible that due to bundling and code minimization, the class `KDBush` was renamed. Since the worker function didn't know about this, the KDBush worker ultimately failed.

Fixes #189 

## Checklist

- [x] Provided a concise title as a [semantic commit message](https://www.conventionalcommits.org) (e.g. "fix: correctly handle undefined properties")
- [x] `CHANGELOG.md` updated
- [ ] Tests added or updated
- [ ] Documentation in `README.md` added or updated
- [ ] Example(s) added or updated
- [ ] Screenshot, gif, or video attached for visual changes
