### PR TITLE
feat: add support for linear and constant point scaling via a new property called `pointScaleMode`

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -77,7 +77,7 @@ const scatterplot = createScatterplot({
   pointSize,
   showReticle,
   reticleColor,
-  lassoInitiator: true,
+  lassoInitiator: true
 });
 
 checkSupport(scatterplot);

--- a/public/index.html
+++ b/public/index.html
@@ -502,6 +502,7 @@
   </head>
 
   <body>
+    <div>test</div>
     <div id="modal" class="flex flex-jc-c flex-a-c">
       <div class="flex flex-col flex-jc-c flex-a-c">
         <span id="modal-text" class="no-select"></span>

--- a/src/constants.js
+++ b/src/constants.js
@@ -99,7 +99,7 @@ export const DEFAULT_GAMMA = 1;
 
 // Default styles
 export const MIN_POINT_SIZE = 1;
-export const DEFAULT_POINT_SCALE_MODE = 'proportional';
+export const DEFAULT_POINT_SCALE_MODE = 'default';
 export const DEFAULT_POINT_SIZE = 6;
 export const DEFAULT_POINT_SIZE_SELECTED = 2;
 export const DEFAULT_POINT_OUTLINE_WIDTH = 2;

--- a/src/constants.js
+++ b/src/constants.js
@@ -99,6 +99,7 @@ export const DEFAULT_GAMMA = 1;
 
 // Default styles
 export const MIN_POINT_SIZE = 1;
+export const DEFAULT_POINT_SCALE_MODE = 'proportional';
 export const DEFAULT_POINT_SIZE = 6;
 export const DEFAULT_POINT_SIZE_SELECTED = 2;
 export const DEFAULT_POINT_OUTLINE_WIDTH = 2;

--- a/src/index.js
+++ b/src/index.js
@@ -82,6 +82,7 @@ import {
   DEFAULT_POINT_CONNECTION_SIZE_ACTIVE,
   DEFAULT_POINT_CONNECTION_SIZE_BY,
   DEFAULT_POINT_OUTLINE_WIDTH,
+  DEFAULT_POINT_SCALE_MODE,
   DEFAULT_POINT_SIZE,
   DEFAULT_POINT_SIZE_MOUSE_DETECTION,
   DEFAULT_POINT_SIZE_SELECTED,
@@ -278,6 +279,7 @@ const createScatterplot = (
     opacityInactiveMax = DEFAULT_OPACITY_INACTIVE_MAX,
     opacityInactiveScale = DEFAULT_OPACITY_INACTIVE_SCALE,
     sizeBy = DEFAULT_SIZE_BY,
+    pointScaleMode = DEFAULT_POINT_SCALE_MODE,
     height = DEFAULT_HEIGHT,
     width = DEFAULT_WIDTH,
     annotationLineColor = DEFAULT_ANNOTATION_LINE_COLOR,
@@ -1475,16 +1477,25 @@ const createScatterplot = (
   const getModel = () => model;
   const getModelViewProjection = () =>
     mat4.multiply(pvm, projection, mat4.multiply(pvm, camera.view, model));
-  const getPointScale = () => {
-    if (camera.scaling[0] > 1) {
-      return (
-        (Math.asinh(max(1.0, camera.scaling[0])) / Math.asinh(1)) *
-        window.devicePixelRatio
-      );
-    }
 
-    return max(minPointScale, camera.scaling[0]) * window.devicePixelRatio;
+  const getPointScale = () => {
+    if (pointScaleMode === 'proportional') {
+      return camera.scaling[0] * window.devicePixelRatio;
+    } 
+    if (pointScaleMode === 'constant') {
+      return window.devicePixelRatio;
+    } 
+    if (pointScaleMode === 'default') {
+      if (camera.scaling[0] > 1) {
+        return (
+          (Math.asinh(max(1.0, camera.scaling[0])) / Math.asinh(1)) *
+          window.devicePixelRatio
+        );
+      }
+      return max(minPointScale, camera.scaling[0]) * window.devicePixelRatio;
+    }
   };
+
   const getNormalNumPoints = () =>
     isPointsFiltered ? filteredPointsSet.size : numPoints;
   const getSelectedNumPoints = () => selectedPoints.length;

--- a/src/index.js
+++ b/src/index.js
@@ -1481,10 +1481,10 @@ const createScatterplot = (
   const getPointScale = () => {
     if (pointScaleMode === 'proportional') {
       return camera.scaling[0] * window.devicePixelRatio;
-    } 
+    }
     if (pointScaleMode === 'constant') {
       return window.devicePixelRatio;
-    } 
+    }
     if (pointScaleMode === 'default') {
       if (camera.scaling[0] > 1) {
         return (


### PR DESCRIPTION
> Write one to two sentences summarizing this PR

This introduces two new modes: 
(1) point size is kept constant, independent of zoom
(2) point size is proportional to zoom.

> What was changed in this pull request?

- the getPointScale method in index.js
- an additional attribute POINT_SCALE_MODE was introduced, which allows to switch between three modes: 'constant', 'proportional' and 'default. 

> Why is it necessary?

Fixes #169 

## Checklist

- [x] Provided a concise title as a [semantic commit message](https://www.conventionalcommits.org) (e.g. "fix: correctly handle undefined properties")
- [ ] `CHANGELOG.md` updated
- [ ] Tests added or updated
- [ ] Documentation in `README.md` added or updated
- [ ] Example(s) added or updated
- [ ] Screenshot, gif, or video attached for visual changes


