### PR TITLE
fix: filter stacking bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.11.1
+
+- Fix: ensure that the drawing order of points cannot be manipulated via `scatterplot.filter()` ([#197](https://github.com/flekschas/regl-scatterplot/issues/197))
+
 ## 1.11.0
 
 - Feat: add support for linear and constant point scaling via a new property called `pointScaleMode`.

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.8.3/schema.json",
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
   "organizeImports": {
     "enabled": true
   },

--- a/src/index.js
+++ b/src/index.js
@@ -131,6 +131,7 @@ import {
   dist,
   flipObj,
   getBBox,
+  insertionSort,
   isConditionalArray,
   isDomRect,
   isHorizontalLine,
@@ -2218,32 +2219,35 @@ const createScatterplot = (
    * @param {import('./types').ScatterplotMethodOptions['filter']}
    */
   const filter = (pointIdxs, { preventEvent = false } = {}) => {
-    const filteredPoints = Array.isArray(pointIdxs) ? pointIdxs : [pointIdxs];
-
     isPointsFiltered = true;
     filteredPointsSet.clear();
 
+    const pointIdxsArray = Array.isArray(pointIdxs) ? pointIdxs : [pointIdxs];
+    const filteredPoints = [];
     const filteredPointsBuffer = [];
     const filteredSelectedPoints = [];
 
-    for (let i = filteredPoints.length - 1; i >= 0; i--) {
-      const pointIdx = filteredPoints[i];
-
+    for (const pointIdx of pointIdxsArray) {
       if (pointIdx < 0 || pointIdx >= numPoints) {
-        // Remove invalid filtered points
-        filteredPoints.splice(i, 1);
+        // Skip invalid filtered points
         continue;
       }
 
+      filteredPoints.push(pointIdx);
       filteredPointsSet.add(pointIdx);
-      filteredPointsBuffer.push.apply(
-        filteredPointsBuffer,
-        indexToStateTexCoord(pointIdx),
-      );
 
       if (selectedPointsSet.has(pointIdx)) {
         filteredSelectedPoints.push(pointIdx);
       }
+    }
+
+    const sortedFilteredPoints = insertionSort([...filteredPoints]);
+
+    for (const pointIdx of sortedFilteredPoints) {
+      filteredPointsBuffer.push.apply(
+        filteredPointsBuffer,
+        indexToStateTexCoord(pointIdx),
+      );
     }
 
     // Update the normal points index buffers

--- a/src/utils.js
+++ b/src/utils.js
@@ -526,3 +526,19 @@ export const isRect = (annotation) =>
 
 export const isPolygon = (annotation) =>
   'vertices' in annotation && annotation.vertices.length > 1;
+
+export const insertionSort = (array) => {
+  const end = array.length;
+  for (let i = 1; i < end; i++) {
+    // Choosing the first element in our unsorted subarray
+    const current = array[i];
+    // The last element of our sorted subarray
+    let j = i - 1;
+    while (j > -1 && current < array[j]) {
+      array[j + 1] = array[j];
+      j--;
+    }
+    array[j + 1] = current;
+  }
+  return array;
+};


### PR DESCRIPTION
This PR fixes the stacking issues when filtering points

## Description

> What was changed in this pull request?

This PR ensures that the order of points to be filtered cannot be altered externally. E.g., `scatterplot.filter([0, 1])` and `scatterplot.filter([1, 0])` is now going to give the same results. Previously, the order of point IDs defined the drawing order.

> Why is it necessary?

Fixes #197 

> Example

Following the example from https://github.com/flekschas/regl-scatterplot/issues/197, when filtering by `scatterplot.filter([0, 1])`, the following happened:

**Previously**

https://github.com/user-attachments/assets/26cda31c-f1b1-49ba-9b04-6279bc9c4582

**Now**

https://github.com/user-attachments/assets/b75ea728-c29e-4bbf-aeab-f9d209209dcd


## Checklist

- [x] Provided a concise title as a [semantic commit message](https://www.conventionalcommits.org) (e.g. "fix: correctly handle undefined properties")
- [x] `CHANGELOG.md` updated
- [x] Tests added or updated
- [ ] Documentation in `README.md` added or updated
- [ ] Example(s) added or updated
- [x] Screenshot, gif, or video attached for visual changes
