### PR TITLE
fix: edge case where `zoomToOrigin` unsets the fixed camera

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.11.3
+
+- Fix: catch another edge case where `zoomToOrigin` was unsetting the camera fixed state
+
 ## 1.11.2
 
 - Fix: handle camera fixing better by adding a dedicated prop called `cameraIsFixed`. Previously, the lasso end interaction would unset the camera fixing. ([#94](https://github.com/flekschas/regl-scatterplot/issues/94))

--- a/src/index.js
+++ b/src/index.js
@@ -2780,7 +2780,7 @@ const createScatterplot = (
           'transitionEnd',
           () => {
             resolve();
-            camera.config({ isFixed: false });
+            camera.config({ isFixed: cameraIsFixed });
           },
           1,
         );

--- a/tests/get-set.test.js
+++ b/tests/get-set.test.js
@@ -661,6 +661,10 @@ test('set({ cameraIsFixed })', async () => {
   scatterplot.set({ cameraIsFixed: true });
   expect(scatterplot.get('cameraIsFixed')).toBe(true);
 
+  // Adding this here to triple check that the programmatic zoom does not unset
+  // the camera fixed state
+  await scatterplot.zoomToOrigin();
+
   canvas.dispatchEvent(new WheelEvent('wheel', { deltaY: -100 }));
 
   await nextAnimationFrame();


### PR DESCRIPTION
This PR fixes another edge case where `zoomToOrigin` was unsetting the camera fixed state.

## Description

> What was changed in this pull request?

`zoomToLocation` (and `zoomToOrigin` as a consequence) had accidentally unset the camera fixed state. Now they respect the `cameraIsFixed` setting

## Checklist

- [x] Provided a concise title as a [semantic commit message](https://www.conventionalcommits.org) (e.g. "fix: correctly handle undefined properties")
- [x] `CHANGELOG.md` updated
- [x] Tests added or updated
- [ ] Documentation in `README.md` added or updated
- [ ] Example(s) added or updated
- [ ] Screenshot, gif, or video attached for visual changes
