### PR TITLE
feat: improve export functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.12.0
+
+- Feat: add support for adjusting the anti-aliasing via `scatterplot.set({ antiAliasing: 1 })`. ([#175](https://github.com/flekschas/regl-scatterplot/issues/175))
+- Feat: add support for aligning points with the pixel grid via `scatterplot.set({ pixelAligned: true })`. ([#175](https://github.com/flekschas/regl-scatterplot/issues/175))
+- Feat: enhance `scatterplot.export()` by allowing to adjust the scale, anti-aliasing, and pixel alignment. Note that when customizing the render setting for export, the function returns a promise that resolves into `ImageData`.
+- Feat: expose `resize()` method of the `renderer`.
+
 ## 1.11.4
 
 - Fix: allow setting the lasso long press indicator parent element

--- a/README.md
+++ b/README.md
@@ -707,9 +707,12 @@ Sets the view back to the initially defined view. This will trigger a `view` eve
 
 **Arguments:**
 
-- `options` is an object for customizing how to export. See [regl.read()](https://github.com/regl-project/regl/blob/master/API.md#reading-pixels) for details.
+- `options` is an object for customizing the render settings during the export:
+  - `scale`: is a float number allowning to adjust the exported image size
+  - `antiAliasing`: is a float allowing to adjust the anti-aliasing factor
+  - `pixelAligned`: is a Boolean allowing to adjust the point alignment with the pixel grid
 
-**Returns:** an object with three properties: `pixels`, `width`, and `height`. The `pixels` is a `Uint8ClampedArray`.
+**Returns:** an [`ImageData`](https://developer.mozilla.org/en-US/docs/Web/API/ImageData) object if `option` is `undefined`. Otherwise it returns a Promise resolving to an [`ImageData`](https://developer.mozilla.org/en-US/docs/Web/API/ImageData) object.
 
 <a name="scatterplot.subscribe" href="#scatterplot.subscribe">#</a> scatterplot.<b>subscribe</b>(<i>eventName</i>, <i>eventHandler</i>)
 
@@ -818,6 +821,8 @@ can be read and written via [`scatterplot.get()`](#scatterplot.get) and [`scatte
 | annotationLineColor                   | string or quadruple                          | `[1, 1, 1, 0.1]`                    | hex, rgb, rgba                                                  | `true`   | `false`     |
 | annotationLineWidth                   | number                                       | `1`                                 |                                                                 | `true`   | `false`     |
 | annotationHVLineLimit                 | number                                       | `1000`                              | the extent of horizontal or vertical lines                      | `true`   | `false`     |
+| antiAliasing                          | number                                       | `0.5`                               | higher values result in more blurry points                      | `true`   | `false`     |
+| pixelAligned                          | number                                       | `false`                             | if true, points are aligned with the pixel grid                 | `true`   | `false`     |
 
 <a name="property-notes" href="#property-notes">#</a> <b>Notes:</b>
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -167,6 +167,8 @@ export const W_NAMES = new Set(['w', 'valueW', 'valueB', 'value2', 'value']);
 export const DEFAULT_IMAGE_LOAD_TIMEOUT = 15000;
 export const DEFAULT_SPATIAL_INDEX_USE_WORKER = undefined;
 export const DEFAULT_CAMERA_IS_FIXED = false;
+export const DEFAULT_ANTI_ALIASING = 0.5;
+export const DEFAULT_PIXEL_ALIGNED = false;
 
 // Error messages
 export const ERROR_POINTS_NOT_DRAWN = 'Points have not been drawn';

--- a/src/point.fs
+++ b/src/point.fs
@@ -1,6 +1,8 @@
 const FRAGMENT_SHADER = `
 precision highp float;
 
+uniform float antiAliasing;
+
 varying vec4 color;
 varying float finalPointSize;
 
@@ -11,7 +13,7 @@ float linearstep(float edge0, float edge1, float x) {
 void main() {
   vec2 c = gl_PointCoord * 2.0 - 1.0;
   float sdf = length(c) * finalPointSize;
-  float alpha = linearstep(finalPointSize + 0.5, finalPointSize - 0.5, sdf);
+  float alpha = linearstep(finalPointSize + antiAliasing, finalPointSize - antiAliasing, sdf);
 
   gl_FragColor = vec4(color.rgb, alpha * color.a);
 }

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -144,7 +144,10 @@ export const createRenderer = (
     }
   });
 
-  const resize = () => {
+  const resize = (
+    /** @type {number} */ customWidth,
+    /** @type {number} */ customHeight,
+  ) => {
     // We need to limit the width and height by the screen size to prevent
     // a bug in VSCode where the window height is said to be taller than the
     // screen height. The problem with too large dimensions is that at some
@@ -157,8 +160,14 @@ export const createRenderer = (
     // @see
     // https://github.com/microsoft/vscode/issues/225808
     // https://github.com/flekschas/jupyter-scatter/issues/37
-    const width = Math.min(window.innerWidth, window.screen.availWidth);
-    const height = Math.min(window.innerHeight, window.screen.availHeight);
+    const width =
+      customWidth === undefined
+        ? Math.min(window.innerWidth, window.screen.availWidth)
+        : customWidth;
+    const height =
+      customHeight === undefined
+        ? Math.min(window.innerHeight, window.screen.availHeight)
+        : customHeight;
     canvas.width = width * window.devicePixelRatio;
     canvas.height = height * window.devicePixelRatio;
     fboRes[0] = canvas.width;
@@ -166,9 +175,13 @@ export const createRenderer = (
     fbo.resize(...fboRes);
   };
 
+  const resizeHandler = () => {
+    resize();
+  };
+
   if (!options.canvas) {
-    window.addEventListener('resize', resize);
-    window.addEventListener('orientationchange', resize);
+    window.addEventListener('resize', resizeHandler);
+    window.addEventListener('orientationchange', resizeHandler);
     resize();
   }
 
@@ -177,8 +190,8 @@ export const createRenderer = (
    */
   const destroy = () => {
     isDestroyed = true;
-    window.removeEventListener('resize', resize);
-    window.removeEventListener('orientationchange', resize);
+    window.removeEventListener('resize', resizeHandler);
+    window.removeEventListener('orientationchange', resizeHandler);
     frame.cancel();
     canvas = undefined;
     regl.destroy();
@@ -229,6 +242,7 @@ export const createRenderer = (
       return isDestroyed;
     },
     render,
+    resize,
     onFrame,
     refresh,
     destroy,

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -165,6 +165,8 @@ interface BaseOptions {
   yScale: null | Scale;
   pointScaleMode: PointScaleMode;
   cameraIsFixed: boolean;
+  antiAliasing: number;
+  pixelAligned: boolean;
 }
 
 // biome-ignore lint/style/useNamingConvention: KDBush is a library name
@@ -264,6 +266,11 @@ export interface ScatterplotMethodOptions {
     transition: boolean;
     transitionDuration: number;
     transitionEasing: (t: number) => number;
+  }>;
+  export: Partial<{
+    scale: number;
+    antiAliasing: number;
+    pixelAligned: boolean;
   }>;
 }
 

--- a/tests/methods.test.js
+++ b/tests/methods.test.js
@@ -896,3 +896,35 @@ test('pointScaleMode', async () => {
 
   scatterplot.destroy();
 });
+
+test('export()', async () => {
+  const dim = 10;
+  const scatterplot = createScatterplot({
+    canvas: createCanvas(dim, dim),
+    width: dim,
+    height: dim,
+    pointSize: 4,
+  });
+
+  await scatterplot.draw([[0.01, 0.01]]);
+
+  const initialImage = scatterplot.export();
+  const initialPixelSum = getPixelSum(initialImage, 0, dim, 0, dim);
+
+  expect(initialPixelSum).toBeGreaterThan(0);
+
+  // Export at two scale
+  const upscaledImage = await scatterplot.export({ scale: 2 });
+  const upscaledPixelSum = getPixelSum(upscaledImage, 0, dim * 2, 0, dim * 2);
+  expect(upscaledPixelSum).toBeGreaterThan(initialPixelSum);
+
+  // Align point with pixel grid
+  const pixelAlignedImage = await scatterplot.export({ pixelAligned: true });
+  expect(pixelAlignedImage.data).not.toEqual(initialImage.data);
+
+  // Increase anti aliasing
+  const antiAliasingImage = await scatterplot.export({ antiAliasing: 2 });
+  const antiAliasingPixelSum = getPixelSum(antiAliasingImage, 0, dim, 0, dim);
+
+  expect(antiAliasingPixelSum).toBeLessThan(initialPixelSum);
+});


### PR DESCRIPTION
This PR improves `scatterplot.export()` by allowing to customize the rendering settings during the export.

## Description

> What was changed in this pull request?

- Added `antiAliasing` property to allow adjusting the anti-aliasing of points
- Added `pixelAligned` property to allow aligning points with the pixel grid
- Enhanced `export()` to allow up or down scaling the exported image as well as adjusting the anti-aliasing and pixel alignment settings during export
- Exposed the renderer's `resize()` function in case one wants to resize the renderer's canvas.

> Why is it necessary?

Fixes #175

All changes enable better exporting. E.g., during export it can be useful to upscale the image, render the points a tad smoother by increasing the anti-aliasing and snapping points to the pixel grid.

Huge thanks go to @danr for providing the necessary code changes in #175! 🙏 

## Checklist

- [x] Provided a concise title as a [semantic commit message](https://www.conventionalcommits.org) (e.g. "fix: correctly handle undefined properties")
- [x] `CHANGELOG.md` updated
- [x] Tests added or updated
- [x] Documentation in `README.md` added or updated
- [ ] Example(s) added or updated
- [ ] Screenshot, gif, or video attached for visual changes
