### PR TITLE
fix: prevent premature draw calls and destroy encoding texture prior to recreation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.12.1
+
+- Fix: destroy the encoding texture before recreating it
+- Fix: reject `set()` calls if the instance was destroyed
+- Fix: ensures unnecessary color and encoding texture updates are avoided
+- Fix: color and encoding textures are destroyed upon calling `scatterplot.destroy()`
+- Fix: prevent a minor memory leak in the newly added advanced exporter
+
 ## 1.12.0
 
 - Feat: add support for adjusting the anti-aliasing via `scatterplot.set({ antiAliasing: 1 })`. ([#175](https://github.com/flekschas/regl-scatterplot/issues/175))

--- a/src/constants.js
+++ b/src/constants.js
@@ -172,3 +172,6 @@ export const DEFAULT_PIXEL_ALIGNED = false;
 
 // Error messages
 export const ERROR_POINTS_NOT_DRAWN = 'Points have not been drawn';
+export const ERROR_INSTANCE_IS_DESTROYED = 'The instance was already destroyed';
+export const ERROR_IS_DRAWING =
+  'Ignoring draw call as the previous draw call has not yet finished. To avoid this warning `await` the draw call.';

--- a/src/utils.js
+++ b/src/utils.js
@@ -312,6 +312,23 @@ export const isMultipleColors = (color) =>
   (Array.isArray(color[0]) || isString(color[0]));
 
 /**
+ * Test if two arrays contain the same primitive values
+ */
+export const isSameElements = (a, b) =>
+  Array.isArray(a) && Array.isArray(b) && a.every((value, i) => value === b[i]);
+
+/**
+ * Test if two arrays contain the same RGBA quadruples
+ */
+export const isSameRgbas = (a, b) =>
+  Array.isArray(a) &&
+  Array.isArray(b) &&
+  a.every(([r1, g1, b1, a1], i) => {
+    const [r2, g2, b2, a2] = b[i];
+    return r1 === r2 && g1 === g2 && b1 === b2 && a1 === a2;
+  });
+
+/**
  * Fast version of `Math.max`. Based on
  *   https://jsperf.com/math-min-max-vs-ternary-vs-if/24 `Math.max` is not
  *   very fast

--- a/tests/events.test.js
+++ b/tests/events.test.js
@@ -35,19 +35,17 @@ test('init and destroy events', async () => {
   });
 
   const whenInit = new Promise((resolve) => {
-    scatterplot.subscribe('init', resolve, 1);
+    scatterplot.subscribe('init', () => resolve(true), 1);
   });
   const whenDestroy = new Promise((resolve) => {
-    scatterplot.subscribe('destroy', resolve, 1);
+    scatterplot.subscribe('destroy', () => resolve(true), 1);
   });
 
-  await whenInit;
+  await expect(whenInit).resolves.toBe(true);
 
   scatterplot.destroy();
 
-  await whenDestroy;
-
-  expect(true).toBe(true);
+  await expect(whenDestroy).resolves.toBe(true);
 });
 
 test('throw an error when calling draw() after destroy()', async () => {

--- a/tests/events.test.js
+++ b/tests/events.test.js
@@ -23,7 +23,6 @@ import {
   createKeyboardEvent,
   wait,
   capitalize,
-  catchError,
 } from './utils';
 
 test('init and destroy events', async () => {

--- a/tests/get-set.test.js
+++ b/tests/get-set.test.js
@@ -22,6 +22,7 @@ import {
   DEFAULT_POINT_CONNECTION_SIZE,
   DEFAULT_POINT_CONNECTION_SIZE_ACTIVE,
   DEFAULT_IMAGE_LOAD_TIMEOUT,
+  ERROR_INSTANCE_IS_DESTROYED,
   IMAGE_LOAD_ERROR,
 } from '../src/constants';
 
@@ -725,4 +726,15 @@ test('get("isDrawing")', async () => {
   expect(scatterplot.get('isDrawing')).toBe(false);
 
   scatterplot.destroy();
+});
+
+
+test('set() after destroy', async () => {
+  const scatterplot = createScatterplot({ canvas: createCanvas() });
+
+  scatterplot.destroy();
+
+  const whenSet = scatterplot.set({ mouseMode: 'lasso' });
+
+  await expect(whenSet).rejects.toThrow(ERROR_INSTANCE_IS_DESTROYED);
 });

--- a/tests/get-set.test.js
+++ b/tests/get-set.test.js
@@ -648,8 +648,6 @@ test('set({ cameraIsFixed })', async () => {
 
   await nextAnimationFrame();
 
-  console.log('1. camera distance', scatterplot.get('camera').distance[0]);
-
   // We expect the distance to be less than one because we zoomed into the plot
   // via wheeling
   expect(scatterplot.get('camera').distance[0]).toBeLessThan(1);
@@ -692,6 +690,39 @@ test('set({ cameraIsFixed })', async () => {
   // mouse wheel interactions are prevented
   expect(scatterplot.get('cameraIsFixed')).toBe(true);
   expect(scatterplot.get('camera').distance[0]).toBeLessThan(1);
+
+  scatterplot.destroy();
+});
+
+test('get("isDestroyed")', async () => {
+  const scatterplot = createScatterplot({ canvas: createCanvas() });
+
+  expect(scatterplot.get('isDestroyed')).toBe(false);
+
+  scatterplot.destroy();
+
+  expect(scatterplot.get('isDestroyed')).toBe(true);
+});
+
+test('get("isDrawing")', async () => {
+  const canvas = createCanvas();
+  const scatterplot = createScatterplot({ canvas });
+
+  expect(scatterplot.get('isDrawing')).toBe(false);
+
+  const whenDrawn = scatterplot.draw([
+    [-1, 1],
+    [1, 1],
+    [0, 0],
+    [-1, -1],
+    [1, -1],
+  ]);
+
+  expect(scatterplot.get('isDrawing')).toBe(true);
+
+  await expect(whenDrawn).resolves.toBe(undefined);
+
+  expect(scatterplot.get('isDrawing')).toBe(false);
 
   scatterplot.destroy();
 });

--- a/tests/methods.test.js
+++ b/tests/methods.test.js
@@ -6,6 +6,8 @@ import createScatterplot from '../src';
 
 import {
   DEFAULT_POINT_SCALE_MODE,
+  ERROR_INSTANCE_IS_DESTROYED,
+  ERROR_IS_DRAWING,
   ERROR_POINTS_NOT_DRAWN,
 } from '../src/constants';
 
@@ -122,6 +124,34 @@ test('draw() with preventFilterReset', async () => {
   ).toBe(true);
 
   scatterplot.destroy();
+});
+
+test('draw() prematurely', async () => {
+  const canvas = createCanvas();
+  const scatterplot = createScatterplot({ canvas });
+
+  const whenDrawn1 = scatterplot.draw([[-1, 1], [0, 0], [1, -1]]);
+  const whenDrawn2 = scatterplot.draw([[-1, 1], [0, 0], [1, -1]]);
+  await expect(whenDrawn2).rejects.toThrow(ERROR_IS_DRAWING);
+
+  await expect(whenDrawn1).resolves.toBe(undefined);
+
+  const whenDrawn3 = scatterplot.draw([[-1, 1], [0, 0], [1, -1]]);
+
+  await expect(whenDrawn3).resolves.toBe(undefined);
+
+  scatterplot.destroy();
+});
+
+test('draw() after destroy', async () => {
+  const canvas = createCanvas();
+  const scatterplot = createScatterplot({ canvas });
+
+  scatterplot.destroy();
+
+  const whenDrawn = scatterplot.draw([[-1, 1], [0, 0], [1, -1]]);
+
+  await expect(whenDrawn).rejects.toThrow(ERROR_INSTANCE_IS_DESTROYED);
 });
 
 test('select()', async () => {

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -57,14 +57,6 @@ export const wait = (milliSeconds) =>
 
 export const capitalize = (s) => `${s[0].toUpperCase}${s.slice(1)}`;
 
-export const catchError = (testFn) => async (t) => {
-  try {
-    await testFn(t);
-  } catch (e) {
-    t.fail(e.message);
-  }
-};
-
 export const isSameElements = (a, b) => {
   if (a.length !== b.length) return false;
   const aSet = new Set(a);


### PR DESCRIPTION
This PR fixes the WebGL texture bug that appears when one frequently changed the point encoding (point color, size, and opacity)

## Description

> What was changed in this pull request?

- Fix: destroy the encoding texture before recreating it
- Fix: reject `set()` calls if the instance was destroyed
- Fix: ensures unnecessary color and encoding texture updates are avoided
- Fix: color and encoding textures are destroyed upon calling `scatterplot.destroy()`
- Fix: prevent a minor memory leak in the newly added advanced exporter

> Why is it necessary?

Fixes #165 

> Example

**Before**

After ~30 draw calls the WebGL described in #165 appears:

https://github.com/user-attachments/assets/600f4f7b-a4f3-4a9e-aa5c-15bb543b1534

**After**

With this fix, the error does not appear:

https://github.com/user-attachments/assets/5e7a37e8-5cd7-4f10-84ab-0badfb02bfc0

I let it run until 1000 draw calls and everything worked just fine.

## Checklist

- [x] Provided a concise title as a [semantic commit message](https://www.conventionalcommits.org) (e.g. "fix: correctly handle undefined properties")
- [x] `CHANGELOG.md` updated
- [x] Tests added or updated
- [ ] Documentation in `README.md` added or updated
- [ ] Example(s) added or updated
- [x] Screenshot, gif, or video attached for visual changes
