### PR TITLE
Fix: prevent drawing points if all are filtered out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.12.1
+
+- Fix: prevent drawing points if all are filtered out ([#201](https://github.com/flekschas/regl-scatterplot/issues/201))
+
 ## 1.12.0
 
 - Feat: add support for adjusting the anti-aliasing via `scatterplot.set({ antiAliasing: 1 })`. ([#175](https://github.com/flekschas/regl-scatterplot/issues/175))

--- a/src/index.js
+++ b/src/index.js
@@ -2242,7 +2242,7 @@ const createScatterplot = (
     const filteredSelectedPoints = [];
 
     for (const pointIdx of pointIdxsArray) {
-      if (pointIdx < 0 || pointIdx >= numPoints) {
+      if (!Number.isFinite(pointIdx) || pointIdx < 0 || pointIdx >= numPoints) {
         // Skip invalid filtered points
         continue;
       }
@@ -4281,7 +4281,8 @@ const createScatterplot = (
         });
       }
 
-      if (isPointsDrawn) {
+      const numPoints = getNormalNumPoints();
+      if (isPointsDrawn && numPoints > 0) {
         drawPointBodies();
       }
 


### PR DESCRIPTION
This PR ensures that when the number of points to be drawn is zero, the points draw is skipped.

## Description

> What was changed in this pull request?

1. Skip drawing points if there aren't any to draw
2. Ensure that `scatterplot.filter()` only treats finite numbers as valid indices (i.e., `scatterplot.filter([])` and `scatterplot.filter([undefined])` behave identical now)

> Why is it necessary?

Fixes #201 

> Examples

**Before**

https://github.com/user-attachments/assets/19715714-3f3c-4ad0-bf81-0c76b199752a

**After**

https://github.com/user-attachments/assets/fa66f87e-4be8-4ccd-a2f3-081b7a2f28f9

## Checklist

- [x] Provided a concise title as a [semantic commit message](https://www.conventionalcommits.org) (e.g. "fix: correctly handle undefined properties")
- [x] `CHANGELOG.md` updated
- [ ] Tests added or updated
- [ ] Documentation in `README.md` added or updated
- [ ] Example(s) added or updated
- [x] Screenshot, gif, or video attached for visual changes
