### PR TITLE
fix: regression from #208 where new points properly set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.13.1
+
+- Fix: an issue where new colors wouldn't be set properly ([#214](https://github.com/flekschas/regl-scatterplot/issues/214))
+
 ## 1.13.0
 
 - Feat: add support for two new lasso types: `'rectangle'` and `'brush'`. The lasso type can be changed via `lassoType`. Additionally, for the brush lasso, you can adjust the brush size via `lassoBrushSize`. The default lasso type is `'freeform'`. ([#186](https://github.com/flekschas/regl-scatterplot/issues/186))

--- a/src/utils.js
+++ b/src/utils.js
@@ -323,6 +323,7 @@ export const isSameElements = (a, b) =>
 export const isSameRgbas = (a, b) =>
   Array.isArray(a) &&
   Array.isArray(b) &&
+  a.length === b.length &&
   a.every(([r1, g1, b1, a1], i) => {
     const [r2, g2, b2, a2] = b[i];
     return r1 === r2 && g1 === g2 && b1 === b2 && a1 === a2;

--- a/tests/get-set.test.js
+++ b/tests/get-set.test.js
@@ -411,6 +411,18 @@ test(
         )
     ).toBe(true);
 
+    // Add another point color to the existing point colors
+    const newPointColors = [...pointColor, [1, 0, 1, 1]];
+    scatterplot.set({
+      pointColor: newPointColors,
+    });
+
+    expect(
+      scatterplot
+        .get('pointColor')
+        .every((color, i) => color.every((c, j) => c === newPointColors[i][j]))
+    ).toBe(true);
+
     scatterplot.set({
       pointConnectionColor: ['#ff0000', '#ff00ff'],
       pointConnectionColorActive: ['#ffff00', '#0000ff'],


### PR DESCRIPTION
This PR fixes a regression from #208 that prevented new point colors from being set if the old point colors were a prefix of the new point colors

## Description

> What was changed in this pull request?

I forgot to check whether the old and new point colors have the same length in `isSameRgbas()`

> Why is it necessary?

Fixes #214 

> Example

https://github.com/user-attachments/assets/7292fa10-f6c2-40e3-9995-09371d2ccf82

## Checklist

- [x] Provided a concise title as a [semantic commit message](https://www.conventionalcommits.org) (e.g. "fix: correctly handle undefined properties")
- [x] `CHANGELOG.md` updated
- [x] Tests added or updated
- [ ] Documentation in `README.md` added or updated
- [ ] Example(s) added or updated
- [x] Screenshot, gif, or video attached for visual changes
