### PR TITLE
fix: improve brush selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.13.2
+
+- Fix: replace the even-odd rule based with the non-zero winding rule for `isPointInPolygon()` to correctly handle overlapping/looping selections. Previosuly points that would fall within the overlapping area would falsely be excluded from the selection instead of being included.
+
 ## 1.13.1
 
 - Fix: an issue where new colors wouldn't be set properly ([#214](https://github.com/flekschas/regl-scatterplot/issues/214))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.13.2
 
 - Fix: replace the even-odd rule based with the non-zero winding rule for `isPointInPolygon()` to correctly handle overlapping/looping selections. Previosuly points that would fall within the overlapping area would falsely be excluded from the selection instead of being included.
+- Fix: Smooth the brush normal to avoid jitter
 
 ## 1.13.1
 

--- a/src/lasso-manager/utils.js
+++ b/src/lasso-manager/utils.js
@@ -1,0 +1,40 @@
+/**
+ * Calculates exponential moving average of 2D points
+ * @param {[number, number][]} values - Array of numbers to average
+ * @param {number} halfLife - Number of steps after which weight becomes half
+ * @param {number} windowSize - Maximum number of previous values to consider
+ * @returns {number} The exponential moving average
+ */
+export const exponentialMovingAverage = (values, halfLife, windowSize) => {
+  if (values.length === 0) {
+    return 0;
+  }
+
+  if (values.length === 1) {
+    return values[0];
+  }
+
+  // Calculate decay factor from `halfLife` such that weight = 0.5 when the
+  // step is `halfLife`
+  const decayBase = 2 ** (-1 / halfLife);
+
+  // Limit to window size
+  const startIdx = Math.max(0, values.length - windowSize);
+  const relevantValues = values.slice(startIdx);
+
+  let weightedSumX = 0;
+  let weightedSumY = 0;
+  let weightSum = 0;
+
+  // Calculate weighted sum starting from most recent value
+  for (let i = relevantValues.length - 1; i >= 0; i--) {
+    const steps = relevantValues.length - 1 - i;
+    const weight = decayBase ** steps;
+
+    weightedSumX += relevantValues[i][0] * weight;
+    weightedSumY += relevantValues[i][1] * weight;
+    weightSum += weight;
+  }
+
+  return [weightedSumX / weightSum, weightedSumY / weightSum];
+};


### PR DESCRIPTION
This PR improves the brush selection

## Description

> What was changed in this pull request?

1. Loops don't negate the selection. I.e., points that fall within the overlapping area of a loop are properly selected
2. Smooth the brush normal to avoid too jittery brush

> Why is it necessary?

Because this is cool

> Example

https://github.com/user-attachments/assets/05c49503-e9d9-4d8b-b8f5-4be7f79c34b5

## Checklist

- [x] Provided a concise title as a [semantic commit message](https://www.conventionalcommits.org) (e.g. "fix: correctly handle undefined properties")
- [x] `CHANGELOG.md` updated
- [ ] Tests added or updated
- [ ] Documentation in `README.md` added or updated
- [ ] Example(s) added or updated
- [x] Screenshot, gif, or video attached for visual changes
