### PR TITLE
feat: expose if view has changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.14.0
+
+- Feat: expose a flag indicating a view change for events `draw`, `drawing`, and `view`
+
 ## 1.13.2
 
 - Fix: replace the even-odd rule based with the non-zero winding rule for `isPointInPolygon()` to correctly handle overlapping/looping selections. Previosuly points that would fall within the overlapping area would falsely be excluded from the selection instead of being included.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.14.0
 
 - Feat: expose a flag indicating a view change for events `draw`, `drawing`, and `view`
+- Fix: clean up worker URL after creation
 
 ## 1.13.2
 

--- a/README.md
+++ b/README.md
@@ -1051,26 +1051,26 @@ Render Regl draw instructions into a target canvas using the renderer.
 
 ### Events
 
-| Name                 | Trigger                                    | Payload                            |
-| -------------------- | ------------------------------------------ | ---------------------------------- |
-| init                 | when the scatter plot is initialized       | `undefined`                        |
-| destroy              | when the scatter plot is destroyed         | `undefined`                        |
-| backgroundImageReady | when the background image was loaded       | `undefined`                        |
-| pointOver            | when the mouse cursor is over a point      | pointIndex                         |
-| pointOut             | when the mouse cursor moves out of a point | pointIndex                         |
-| select               | when points are selected                   | `{ points }`                       |
-| deselect             | when points are deselected                 | `undefined`                        |
-| filter               | when points are filtered                   | `{ points }`                       |
-| unfilter             | when the point filter is reset             | `undefined`                        |
-| view                 | when the view has changes                  | `{ camera, view, xScale, yScale }` |
-| draw                 | when the plot was drawn                    | `{ camera, view, xScale, yScale }` |
-| drawing              | when the plot is being drawn               | `{ camera, view, xScale, yScale }` |
-| lassoStart           | when the lasso selection has started       | `undefined`                        |
-| lassoExtend          | when the lasso selection has extended      | `{ coordinates }`                  |
-| lassoEnd             | when the lasso selection has ended         | `{ coordinates }`                  |
-| transitionStart      | when points started to transition          | `undefined`                        |
-| transitionEnd        | when points ended to transition            | `createRegl(canvas)`               |
-| pointConnectionsDraw | when point connections were drawn          | `undefined`                        |
+| Name                 | Trigger                                    | Payload                                           |
+| -------------------- | ------------------------------------------ | ------------------------------------------------- |
+| init                 | when the scatter plot is initialized       | `undefined`                                       |
+| destroy              | when the scatter plot is destroyed         | `undefined`                                       |
+| backgroundImageReady | when the background image was loaded       | `undefined`                                       |
+| pointOver            | when the mouse cursor is over a point      | pointIndex                                        |
+| pointOut             | when the mouse cursor moves out of a point | pointIndex                                        |
+| select               | when points are selected                   | `{ points }`                                      |
+| deselect             | when points are deselected                 | `undefined`                                       |
+| filter               | when points are filtered                   | `{ points }`                                      |
+| unfilter             | when the point filter is reset             | `undefined`                                       |
+| view                 | when the view has changes                  | `{ camera, view, isViewChanged, xScale, yScale }` |
+| draw                 | when the plot was drawn                    | `{ camera, view, isViewChanged, xScale, yScale }` |
+| drawing              | when the plot is being drawn               | `{ camera, view, isViewChanged, xScale, yScale }` |
+| lassoStart           | when the lasso selection has started       | `undefined`                                       |
+| lassoExtend          | when the lasso selection has extended      | `{ coordinates }`                                 |
+| lassoEnd             | when the lasso selection has ended         | `{ coordinates }`                                 |
+| transitionStart      | when points started to transition          | `undefined`                                       |
+| transitionEnd        | when points ended to transition            | `createRegl(canvas)`                              |
+| pointConnectionsDraw | when point connections were drawn          | `undefined`                                       |
 
 ## Trouble Shooting
 

--- a/src/index.js
+++ b/src/index.js
@@ -4467,6 +4467,7 @@ const createScatterplot = (
 
     const renderView = {
       view: camera.view,
+      isViewChanged,
       camera,
       xScale,
       yScale,

--- a/src/kdbush.js
+++ b/src/kdbush.js
@@ -16,13 +16,14 @@ const createWorker = (fn) => {
     `const createWorker = ${fnStr};` +
     'createWorker();';
 
-  return new Worker(
-    window.URL.createObjectURL(
-      new Blob([workerStr], {
-        type: 'text/javascript',
-      }),
-    ),
-  );
+  const blob = new Blob([workerStr], { type: 'text/javascript' });
+  const workerUrl = URL.createObjectURL(blob);
+  const worker = new Worker(workerUrl, { name: 'KDBush' });
+
+  // Clean up URL
+  URL.revokeObjectURL(workerUrl);
+
+  return worker;
 };
 
 /**


### PR DESCRIPTION
This PR exposes `isViewChanged` in the payload of `draw`, `drawing`, and `view` events

## Description

### What was changed in this pull request?

- Exposes `isViewChanged` in the payload of `draw`, `drawing`, and `view` events
- Clean up worker URL after creation

### Why is this PR necessary?

To make it easier for consumers to know whether a draw call was triggered by a view change

## Checklist

- [x] Provided a concise title as a [semantic commit message](https://www.conventionalcommits.org) (e.g. "fix: correctly handle undefined properties")
- [x] `CHANGELOG.md` updated
- [ ] Tests added or updated
- [x] Documentation in `README.md` added or updated
- [ ] Example(s) added or updated
- [ ] Screenshot, gif, or video attached for visual changes
